### PR TITLE
update styles: project page, button styles, logo, file download ux

### DIFF
--- a/dcp_prototype/frontend/src/components/authenticate.js
+++ b/dcp_prototype/frontend/src/components/authenticate.js
@@ -1,34 +1,31 @@
 import React from "react"
 import { useAuth0 } from "../contexts/auth0Context"
-import { Box, Button, Image } from "theme-ui"
+import { Box, Flex, Image } from "theme-ui"
+import StyledButton from "./styledButton"
 
 const Authenticate = () => {
   const { isAuthenticated, loading, user, logout, loginWithRedirect } = useAuth0()
 
   return (
-    <>
+    <Box>
       {!loading && user && (
-        <>
-          <Button onClick={logout}>
-            Logout
-          </Button>
-
+        <Flex sx={{ alignItems: "center" }}>
+          <StyledButton label="Logout" onclick={logout}/>
           {!user ? (<Box>...</Box>) : (
             <Image src={user.picture}
-                   width="48"
-                   height="48"
+                   width="45px"
+                   height="45px"
+                   padding="5px"
             />
           )}
-        </>
+        </Flex>
       )}
       {!loading && !isAuthenticated && (
         <>
-          <Button onClick={loginWithRedirect}>
-            Login/Sign-up
-          </Button>
+          <StyledButton label="Login/Sign-up" onclick={loginWithRedirect}/>
         </>
       )}
-    </>
+    </Box>
   )
 
 }

--- a/dcp_prototype/frontend/src/components/exploreData.js
+++ b/dcp_prototype/frontend/src/components/exploreData.js
@@ -1,26 +1,43 @@
 import React from "react"
-import { Flex, Button, Text } from "theme-ui"
+import { Flex, Box, Text } from "theme-ui"
+import StyledButton from "./styledButton"
+import LoginSignup from "./login-signup"
 
 import { api_prefix } from "../globals"
 
-const ExploreData = ({ project, files }) => {
+const ExploreData = ({ project, files, isAuthenticated }) => {
   const cxg_url = "http://cellxgene-dev.us-west-2.elasticbeanstalk.com/"
+  const disabled = !((files && files.length && isAuthenticated) === true)
 
   return (
-    !files || !files.length ? <Text>No files available for download</Text> : (
-      <Flex>
-        <Button onClick={() => fetch(`${api_prefix}/files/${files[0].id}`)
-            .then(response => response.json()) // parse JSON from request
-            .then(resultData => {
-              window.open(resultData.url)
-            })}>
-            Download matrix
-        </Button>
-        <Button onClick={() => window.open(cxg_url + project.title + ".cxg")}>
-            Visualize in cellxgene
-        </Button>
-      </Flex>
-    )
+  <Box sx={{mb: 2}}>
+    <Flex sx={{mb: 1}}>
+      <StyledButton label="Download matrix"
+                    disabled={disabled}
+                    onclick={() => fetch(`${api_prefix}/files/${files[0].id}`)
+                                    .then(response => response.json())
+                                    .then(resultData => {
+                                      window.open(resultData.url)
+                                    })}>
+        Download matrix
+      </StyledButton>
+      <StyledButton label="Visualize in cellxgene"
+                    disabled={disabled}
+                    onclick={() => window.open(cxg_url + project.title + ".cxg")}>
+          Visualize in cellxgene
+      </StyledButton>
+    </Flex>
+    { isAuthenticated ? null : (
+      <Box>
+        <LoginSignup/>
+      </Box>
+    )}
+    { files && !files.length && isAuthenticated ? (
+      <Text sx={{color: "primary", fontSize: 1}}>
+        No files available for download
+      </Text>
+    ) : null }
+  </Box>
   )
 }
 export default ExploreData

--- a/dcp_prototype/frontend/src/components/footer.js
+++ b/dcp_prototype/frontend/src/components/footer.js
@@ -1,14 +1,13 @@
 import { Link } from "gatsby"
 import React from "react"
-import Logo from "./logo2"
-import { Flex, Box } from "theme-ui"
+import { Flex, Box, Image } from "theme-ui"
 
 const Header = ({ siteTitle }) => {
   return (
     <Box
       sx={{
         background: `black`,
-        mt: "0px",
+        mt: [4],
       }}
     >
       <Flex
@@ -16,38 +15,25 @@ const Header = ({ siteTitle }) => {
           alignItems: "center",
           justifyContent: "space-between",
           fontWeight: 700,
-          margin: `0px`,
-          maxWidth: "100%",
+          margin: `0 auto`,
+          maxWidth: "1100px",
           padding: [3],
           paddingLeft: 5,
         }}
       >
         <Box sx={{ width: 112 }}>
-          <a href="https://www.humancellatlas.org/">
-            <Logo />
-          </a>
+          <Link
+            to="/"
+            style={{
+              color: `black`,
+              textDecoration: `none`,
+            }}
+          >
+            <Image src="https://chanzuckerberg.com/wp-content/themes/czi/img/logo-minified.svg"
+                   width="55px"
+                   height="55px"/>
+          </Link>
         </Box>
-        <Box sx={{ color: "white",
-          display: `none`,
-        }}>Data</Box>
-        <Box sx={{ color: "white",
-          display: `none`,
-        }}>Guides</Box>
-        <Box sx={{ color: "white",
-          display: `none`,
-        }}>Metadata</Box>
-        <Box sx={{ color: "white",
-          display: `none`,
-        }}>Pipelines</Box>
-        <Box sx={{ color: "white",
-          display: `none`,
-        }}>Analysis Tools</Box>
-        <Box sx={{ color: "white",
-          display: `none`,
-        }}>Contribute</Box>
-        <Box sx={{ color: "white",
-          display: `none`,
-        }}>APIs</Box>
       </Flex>
     </Box>
   )

--- a/dcp_prototype/frontend/src/components/header.js
+++ b/dcp_prototype/frontend/src/components/header.js
@@ -1,7 +1,6 @@
 import { Link } from "gatsby"
 import React from "react"
-import Logo from "./logo1"
-import { Box, Flex } from "theme-ui"
+import { Box, Flex, Image } from "theme-ui"
 import Authenticate from "./authenticate"
 
 const Header = ({ siteTitle }) => {
@@ -19,13 +18,11 @@ const Header = ({ siteTitle }) => {
           justifyContent: "space-between",
           fontWeight: 700,
           margin: `0 auto`,
-          maxWidth: "100%",
+          maxWidth: "1100px",
           paddingTop: 0,
           paddingBottom: 0,
           paddingLeft: 5,
           paddingRight: 5,
-
-
         }}
       >
         <Box sx={{ width: 175 }}>
@@ -36,37 +33,12 @@ const Header = ({ siteTitle }) => {
               textDecoration: `none`,
             }}
           >
-            <Logo/>
+          <Image src="https://chanzuckerberg.com/wp-content/themes/czi/img/logo-minified.svg"
+                 width="55px"
+                 height="55px"/>
           </Link>
         </Box>
-        <Box
-					style={{
-						display: `none`,
-					}}>Data</Box>
-        <Box
-					style={{
-						display: `none`,
-					}}>Guides</Box>
-        <Box
-					style={{
-						display: `none`,
-					}}>Metadata</Box>
-        <Box
-					style={{
-						display: `none`,
-					}}>Pipelines</Box>
-        <Box
-					style={{
-						display: `none`,
-					}}>Analysis Tools</Box>
-        <Box
-					style={{
-						display: `none`,
-					}}>Contribute</Box>
-        <Box
-					style={{
-						display: `none`,
-					}}>APIs</Box>
+        <Authenticate/>
       </Flex>
     </Box>
   )

--- a/dcp_prototype/frontend/src/components/layout.js
+++ b/dcp_prototype/frontend/src/components/layout.js
@@ -31,7 +31,7 @@ const Layout = ({ children }) => {
       <div
         style={{
           margin: `0 auto`,
-          maxWidth: 1440,
+          maxWidth: 1100,
           minHeight:
             // "100vh", /* for now. better: height minus footer, or go to sticky */
             `calc(100vh - 85px - 60px - 48px)`, // height minus footer, minus header, minus margin between header and "Explore Data"; only way I coudl get footer to level with bottom of screen

--- a/dcp_prototype/frontend/src/components/login-signup.js
+++ b/dcp_prototype/frontend/src/components/login-signup.js
@@ -8,7 +8,7 @@ const LoginSignup = () => {
   return (
     <>
       {!loading && !isAuthenticated && (
-        <Heading as="h4" sx={{ mb: 4 }}>
+        <Heading as="h4" sx={{ color: "primary", fontSize: 1 }}>
           <a href="#" onClick={loginWithRedirect}>Log in</a> or <a href="#" onClick={loginWithRedirect}>sign-up</a> to
           view and download data.
         </Heading>)}

--- a/dcp_prototype/frontend/src/components/login-signup.js
+++ b/dcp_prototype/frontend/src/components/login-signup.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { useAuth0 } from "../contexts/auth0Context"
-import { Heading } from "theme-ui"
+import { Text } from "theme-ui"
 
 const LoginSignup = () => {
   const { isAuthenticated, loading, loginWithRedirect } = useAuth0()
@@ -8,10 +8,10 @@ const LoginSignup = () => {
   return (
     <>
       {!loading && !isAuthenticated && (
-        <Heading as="h4" sx={{ color: "primary", fontSize: 1 }}>
+        <Text sx={{ color: "primary", fontSize: 1 }}>
           <a href="#" onClick={loginWithRedirect}>Log in</a> or <a href="#" onClick={loginWithRedirect}>sign-up</a> to
           view and download data.
-        </Heading>)}
+        </Text>)}
     </>
   )
 }

--- a/dcp_prototype/frontend/src/components/projectOverview.js
+++ b/dcp_prototype/frontend/src/components/projectOverview.js
@@ -1,12 +1,42 @@
 import React from "react"
 import { Flex, Box, Heading, Text } from "theme-ui"
+import ExploreData from "./exploreData"
 
-const ProjectOverview = ({ project }) => {
+const ProjectOverview = ({ project, files, isAuthenticated }) => {
+  const publications = !project.publication_title ? null : (
+      <Box sx={{mb: [4]}}>
+        <Heading as="h6" sx={{ mb: [2] }}>
+          Publications
+        </Heading>
+        <Text>{project.publication_title}</Text>
+      </Box>
+  )
+  const contributors = !project.contributors.length ? null : (
+      <Flex>
+        <Box>
+          <Heading as="h6" sx={{ mb: [2] }}>
+            Contributors
+          </Heading>
+          {project.contributors.map(c => <Text key={c.name}>{c.name}</Text>)}
+        </Box>
+        <Box sx={{ml: [2]}}>
+          <Heading as="h6" sx={{ mb: [2] }}>
+            Institutions
+          </Heading>
+          <Text>{project.contributors[0].institution}</Text>
+        </Box>
+      </Flex>
+  )
   return (
     <Box>
       <Heading as="h3" sx={{ mb: 4 }}>
         {project.title}
       </Heading>
+      {!project ? null : (
+        <Flex sx={{flexDirection: "column"}}>
+          <ExploreData project={project} files={files} isAuthenticated={isAuthenticated}/>
+        </Flex>
+      )}
       <Heading as="h3" sx={{ mb: 4 }}>
         Project Information
       </Heading>
@@ -23,18 +53,8 @@ const ProjectOverview = ({ project }) => {
             </Heading>
             <Text>{project.description}</Text>
           </Box>
-          <Box>
-            <Heading as="h6" sx={{ mb: [2] }}>
-              Publications
-            </Heading>
-            <Text>{project.publication_title}</Text>
-          </Box>
-          <Box>
-            <Heading as="h6" sx={{ mb: [2] }}>
-              Contributors
-            </Heading>
-            <Text>{project.contributors[0].first_name}</Text>
-          </Box>
+          {publications}
+          {contributors}
         </Box>
         <Flex>
           <Box>

--- a/dcp_prototype/frontend/src/components/projectsList.js
+++ b/dcp_prototype/frontend/src/components/projectsList.js
@@ -32,7 +32,7 @@ const ProjectsList = ({ projects }) => {
             >
               <Flex sx={{ flexDirection: "column" }}>
                 {project.organs.map(organ=> (
-                  <Box key={organ}>{organ}</Box>
+                  <Box key={organ}>{organ.charAt(0).toUpperCase() + organ.substring(1)}</Box>
                 ))}
               </Flex>
             </Box>
@@ -78,7 +78,7 @@ const ProjectsList = ({ projects }) => {
                 boxSizing: "border-box",
                 flexGrow: 0,
                 flexShrink: 0,
-                width: `12%`, // Narrower so Project Name has more width; account for right margin of "6" in array = 48px
+                width: `16%`, // Narrower so Project Name has more width; account for right margin of "6" in array = 48px
                 paddingRight: 7,
                 overflow: "hidden", // Or flex might break
                 listStyle: "none",
@@ -93,7 +93,7 @@ const ProjectsList = ({ projects }) => {
                 boxSizing: "border-box",
                 flexGrow: 0,
                 flexShrink: 0,
-                width: `40%`, // Narrower so Project Name has more width; account for right margin of "6" in array = 48px
+                width: `36%`, // Narrower so Project Name has more width; account for right margin of "6" in array = 48px
                 overflow: "hidden", // Or flex might break
                 listStyle: "none",
               }}

--- a/dcp_prototype/frontend/src/components/projectsListHeading.js
+++ b/dcp_prototype/frontend/src/components/projectsListHeading.js
@@ -58,7 +58,7 @@ const ProjectsListHeading = ({ projects }) => {
           boxSizing: "border-box",
           flexGrow: 0,
           flexShrink: 0,
-          width: `12%`, // Narrower so Project Name has more width; account for right margin of "6" in array = 48px
+          width: `16%`, // Narrower so Project Name has more width; account for right margin of "6" in array = 48px
           paddingRight: 7,
           overflow: "hidden", // Or flex might break
           listStyle: "none",
@@ -75,7 +75,7 @@ const ProjectsListHeading = ({ projects }) => {
           boxSizing: "border-box",
           flexGrow: 0,
           flexShrink: 0,
-          width: `40%`, // Narrower so Project Name has more width; account for right margin of "6" in array = 48px
+          width: `36%`, // Narrower so Project Name has more width; account for right margin of "6" in array = 48px
           overflow: "hidden", // Or flex might break
           listStyle: "none",
           fontWeight: 700,

--- a/dcp_prototype/frontend/src/components/styledButton.js
+++ b/dcp_prototype/frontend/src/components/styledButton.js
@@ -1,0 +1,25 @@
+import React from "react"
+import { Button, Text } from "theme-ui"
+
+const StyledButton = ({ label, disabled, onclick }) => {
+  return (
+    <Button sx={{
+                  height: "35px",
+                  minWidth: "100px",
+                  padding: "5px 20px",
+                  textAlign: "center",
+                  borderRadius: "1px",
+                  fontWeight: "100",
+                  margin: "0px 5px",
+                  color: disabled ? "gray" : "white",
+                  backgroundColor: disabled ? "muted" : "steelblue",
+                  cursor: disabled ? "default" : "pointer",
+                  pointerEvents: disabled ? "none" : "default"
+                }}
+             onClick={disabled ? undefined : onclick}>
+      <Text sx={{ fontSize: [0] }}>{label}</Text>
+    </Button>
+  )
+}
+
+export default StyledButton

--- a/dcp_prototype/frontend/src/components/theme.js
+++ b/dcp_prototype/frontend/src/components/theme.js
@@ -22,6 +22,7 @@ export default {
     primary: "red",
     secondary: "#1c7cc705",
     muted: "#f6f6f6",
+    gray: "#bbb"
   },
   styles: {
     root: {
@@ -107,5 +108,8 @@ export default {
     img: {
       maxWidth: "100%",
     },
+    button: {
+      backgorundColor: "blue"
+    }
   },
 }

--- a/dcp_prototype/frontend/src/pages/project.js
+++ b/dcp_prototype/frontend/src/pages/project.js
@@ -4,10 +4,8 @@ import Layout from "../components/layout"
 import SEO from "../components/seo"
 import searchStringAsObj from "../util/searchStringAsObj"
 import ProjectOverview from "../components/projectOverview"
-import ExploreData from "../components/exploreData"
 import { api_prefix } from "../globals"
-import { Box, Flex, Heading } from "theme-ui"
-import LoginSignup from "../components/login-signup"
+import { Flex, Heading } from "theme-ui"
 
 const SecondPage = props => {
   const [project, setProject] = useState(null)
@@ -51,30 +49,16 @@ const SecondPage = props => {
   return (
     <Layout>
       <SEO title="Projects"/>
-      <Heading as="h1" sx={{ mb: 4 }}>
+      <Heading as="h1" sx={{ mb: 5, mt: 6 }}>
         Explore Project
       </Heading>
-      <Flex>
+      <Flex sx={{justifyContent: 'center'}}>
         {!project ? (
           "Loading project..."
         ) : (
-          <ProjectOverview project={project}/>
+          <ProjectOverview project={project} files={files} isAuthenticated={isAuthenticated}/>
         )}
       </Flex>
-      {!project ? null : (
-        <Box>
-          <Heading as="h3" sx={{ mb: 4 }}>
-            Download files
-          </Heading>
-          {isAuthenticated ? (
-                <ExploreData project={project} files={files}/>
-            ) : (
-            <Box sx={{ flex: "1 1 auto" }}>
-              <LoginSignup/>
-            </Box>
-          )}
-        </Box>
-      )}
     </Layout>
   )
 }


### PR DESCRIPTION
Updated browser front-end to improve aesthetics and file download user experience:
- styled project page
- updated button styles
- updated logo to CZI logo
- surfaced data access to top of page
- implemented user flows for unauthenticated and unavailable data scenarios

Closes #35
Closes #200 

Projects list page (PLP):
<img width="1082" alt="Screen Shot 2020-03-19 at 7 33 07 PM" src="https://user-images.githubusercontent.com/4444086/77131481-07742400-6a19-11ea-9469-a68d09f0fb37.png">

Project page (PP):
<img width="1081" alt="Screen Shot 2020-03-19 at 7 33 24 PM" src="https://user-images.githubusercontent.com/4444086/77131489-1064f580-6a19-11ea-9e7f-bbc56f335dc4.png">

Unauthenticated data view:
<img width="354" alt="Screen Shot 2020-03-19 at 7 39 45 PM" src="https://user-images.githubusercontent.com/4444086/77131663-a7ca4880-6a19-11ea-859c-287750689016.png">

Unavailable data view:
<img width="364" alt="Screen Shot 2020-03-19 at 7 34 20 PM" src="https://user-images.githubusercontent.com/4444086/77131510-178c0380-6a19-11ea-871d-b4c45eed73ee.png">

