### PR TITLE
Gatsby Site Deployment With Authentication

### DIFF
--- a/dcp_prototype/frontend/.env.development
+++ b/dcp_prototype/frontend/.env.development
@@ -1,5 +1,5 @@
 # ./.env
 # Get these values at https://manage.auth0.com
 AUTH0_DOMAIN=humancellatlasstaging.auth0.com
-AUTH0_CLIENTID=jTRjpgZkV5nsKy79tYm7vUIGtEblgAhS
-AUTH0_CALLBACK=http://localhost:8000/callback
+AUTH0_CLIENTID=UikiQ2KMnvPgUAcOTRz8h0ELMrXVuSl6
+AUTH0_CALLBACK=http://localhost:8000/

--- a/dcp_prototype/frontend/Makefile
+++ b/dcp_prototype/frontend/Makefile
@@ -1,11 +1,14 @@
 SHELL:=/bin/bash
-export BROWSER_S3=dcp-static-site-test-699936264352
+ACCOUNT_ID=$(shell aws sts get-caller-identity --query Account --output text)
+BROWSER_S3=dcp-static-site-$(DEPLOYMENT_STAGE)-$(ACCOUNT_ID)
+S3_ENVIRONMENT_FILE=s3://$(BROWSER_S3)/env.production
 
 ifndef DEPLOYMENT_STAGE
 $(error Please set the DEPLOYMENT_STAGE environment before deploying)
 endif
 
-deploy: init
+deploy: init retrieve-vars
+
 	npm run build
 	aws s3 sync ./public s3://$(BROWSER_S3)/
 
@@ -16,3 +19,12 @@ init:
 .PHONY: clean
 clean:
 	npm run clean
+
+.PHONY: retrieve-vars
+retrieve-vars:
+	aws s3 cp $(S3_ENVIRONMENT_FILE) .env.production
+
+.PHONY: upload-vars
+upload-vars:
+	aws s3 cp .env.production $(S3_ENVIRONMENT_FILE)
+

--- a/dcp_prototype/frontend/Makefile
+++ b/dcp_prototype/frontend/Makefile
@@ -1,5 +1,5 @@
 SHELL:=/bin/bash
-export BROWSER_S3=dcp-site-deployment-$(DEPLOYMENT_STAGE)
+export BROWSER_S3=dcp-static-site-test-699936264352
 
 ifndef DEPLOYMENT_STAGE
 $(error Please set the DEPLOYMENT_STAGE environment before deploying)

--- a/dcp_prototype/frontend/src/contexts/auth0Context.js
+++ b/dcp_prototype/frontend/src/contexts/auth0Context.js
@@ -5,7 +5,7 @@ import createAuth0Client from "@auth0/auth0-spa-js"
 const config = {
   domain: process.env.AUTH0_DOMAIN,
   client_id: process.env.AUTH0_CLIENTID,
-  redirect_uri: "http://localhost:8000",
+  redirect_uri: process.env.AUTH0_CALLBACK,
 }
 
 export const Auth0Context = React.createContext()

--- a/infra/envs/test/main.tf
+++ b/infra/envs/test/main.tf
@@ -48,10 +48,26 @@ module "siteCert" {
   source = "github.com/chanzuckerberg/cztack//aws-acm-cert?ref=v0.29.0"
 
   # the cert domain name
+  cert_domain_name = "*.dev.single-cell.czi.technology"
+  # the route53 zone for validating the `cert_domain_name`
+  aws_route53_zone_id = "Z3GU3D81Z7R7CN"
+
+  # variables for tags
+  env     = "${var.deployment_stage}"
+  project = "single-cell"
+  service = "browser"
+  owner   = "czi-single-cell"
+}
+
+module "siteCert_Browser" {
+  source = "github.com/chanzuckerberg/cztack//aws-acm-cert?ref=v0.29.0"
+
+  # the cert domain name
   cert_domain_name = "browser.dev.single-cell.czi.technology"
+  cert_subject_alternative_names = {"www.browser.dev.single-cell.czi.technology"= "Z3GU3D81Z7R7CN"}
 
   # the route53 zone for validating the `cert_domain_name`
-  aws_route53_zone_id = "Z0921546EDJ5WWGRFFKB"
+  aws_route53_zone_id = "Z3GU3D81Z7R7CN"
 
   # variables for tags
   env     = "${var.deployment_stage}"
@@ -63,8 +79,8 @@ module "siteCert" {
 module "site" {
   source = "github.com/chanzuckerberg/cztack//aws-single-page-static-site?ref=v0.29.0"
 
-  aws_route53_zone_id            = "Z0921546EDJ5WWGRFFKB"
-  aws_acm_cert_arn = "arn:aws:acm:us-east-1:699936264352:certificate/1cd4873a-16ed-4b0a-a9be-0d7f61c77040"
+  aws_route53_zone_id            = "Z3GU3D81Z7R7CN"
+  aws_acm_cert_arn = "${module.siteCert_Browser.arn}"
   bucket_name = "dcp-static-site-${var.deployment_stage}-${data.aws_caller_identity.current.account_id}"
   subdomain = "browser"
 

--- a/infra/envs/test/main.tf
+++ b/infra/envs/test/main.tf
@@ -44,27 +44,12 @@ provider "aws" {
 //  preferred_maintenance_window = "${var.browser_preferred_maintenance_window}"
 //}
 
-module "siteCert" {
+module "browser_site_cert" {
   source = "github.com/chanzuckerberg/cztack//aws-acm-cert?ref=v0.29.0"
 
   # the cert domain name
-  cert_domain_name = "*.dev.single-cell.czi.technology"
-  # the route53 zone for validating the `cert_domain_name`
-  aws_route53_zone_id = "Z3GU3D81Z7R7CN"
-
-  # variables for tags
-  env     = "${var.deployment_stage}"
-  project = "single-cell"
-  service = "browser"
-  owner   = "czi-single-cell"
-}
-
-module "siteCert_Browser" {
-  source = "github.com/chanzuckerberg/cztack//aws-acm-cert?ref=v0.29.0"
-
-  # the cert domain name
-  cert_domain_name = "browser.dev.single-cell.czi.technology"
-  cert_subject_alternative_names = {"www.browser.dev.single-cell.czi.technology"= "Z3GU3D81Z7R7CN"}
+  cert_domain_name = "browser-testing.dev.single-cell.czi.technology"
+  cert_subject_alternative_names = {"www.browser-testing.dev.single-cell.czi.technology"= "Z3GU3D81Z7R7CN"}
 
   # the route53 zone for validating the `cert_domain_name`
   aws_route53_zone_id = "Z3GU3D81Z7R7CN"
@@ -76,13 +61,13 @@ module "siteCert_Browser" {
   owner   = "czi-single-cell"
 }
 
-module "site" {
+module "browser_frontend" {
   source = "github.com/chanzuckerberg/cztack//aws-single-page-static-site?ref=v0.29.0"
 
   aws_route53_zone_id            = "Z3GU3D81Z7R7CN"
-  aws_acm_cert_arn = "${module.siteCert_Browser.arn}"
+  aws_acm_cert_arn = "${module.browser_site_cert.arn}"
   bucket_name = "dcp-static-site-${var.deployment_stage}-${data.aws_caller_identity.current.account_id}"
-  subdomain = "browser"
+  subdomain = "browser-testing"
 
   # Variables used for tagging
   env     = "${var.deployment_stage}"


### PR DESCRIPTION
- Adding terraform to host the single-cell browser from s3 behind cloudfront and over https. This will allow us to securely deploy the site using CZI-INFRA best practices. 
- This PR also adds the gastby env.production file that will be will be uploaded to the gatsby site bucket and downloaded and used during the deployment of the site. This allows us to store the configuration of the each deployment environment easier.
- There were conflict with the existing dcp site bucket name so I created a new bucket with appends the aws_account_id to the end of the bucket.
- Changed the AUTH0_CLIENT_ID for env.develop. This will allow us to continue to test gatsby locally while the old AUTH0_CLIENT_ID will be used for the host site. There is no security risk in reusing the client ids.