### PR TITLE
Refresh on project page and deep linking fix

### DIFF
--- a/dcp_prototype/frontend/src/components/projectsList.js
+++ b/dcp_prototype/frontend/src/components/projectsList.js
@@ -98,7 +98,7 @@ const ProjectsList = ({ projects }) => {
                 listStyle: "none",
               }}
             >
-              <Link to={`/project?id=${project.id}`}>{project.title}</Link>
+              <Link to={`/project/?id=${project.id}`}>{project.title}</Link>
             </Box>
           </Flex>
         )


### PR DESCRIPTION
- Refreshing on a project page, does not return the user to the index page.
- The url in the browser window of a project page will correctly link back to the project page.

Fixes #217 
Fixes #215