### PR TITLE
Use in-memory SQLite db for testing

### DIFF
--- a/dcp_prototype/backend/browser/code/common/browser_orm.py
+++ b/dcp_prototype/backend/browser/code/common/browser_orm.py
@@ -22,14 +22,18 @@ from browser.code.config.db_config import BrowserDbConfig
 
 
 Base = declarative_base()
+deployment_stage = os.environ["DEPLOYMENT_STAGE"]
+
+# The in-memory SQLite database used in
+# unit tests does not support now() SQL syntax
+DEFAULT_DATETIME = "2000-01-01 00:00:00" if deployment_stage == "test" else text("now()")
 
 
 class DBSessionMaker:
     def __init__(self):
-        engine = create_engine(BrowserDbConfig().database_uri)
-        Base.metadata.bind = engine
-        self.session_maker = sessionmaker()
-        self.session_maker.bind = engine
+        connection = "sqlite:///:memory:" if deployment_stage == "test" else BrowserDbConfig().database_uri
+        self.engine = create_engine(connection)
+        self.session_maker = sessionmaker(bind=self.engine)
 
     def session(self, **kwargs):
         return self.session_maker(**kwargs)
@@ -54,8 +58,8 @@ class Project(Base):
     publication_title = Column(String(200))
     publication_doi = Column(String(32))
     cxg_enabled = Column(Boolean)
-    created_at = Column(DateTime(True), nullable=False, server_default=text("now()"))
-    updated_at = Column(DateTime(True), nullable=False, server_default=text("now()"))
+    created_at = Column(DateTime(True), nullable=False, server_default=DEFAULT_DATETIME)
+    updated_at = Column(DateTime(True), nullable=False, server_default=DEFAULT_DATETIME)
 
 
 class File(Base):
@@ -68,8 +72,8 @@ class File(Base):
     file_size = Column(BigInteger)
     file_type = Column(String(20))
     s3_uri = Column(String(200))
-    created_at = Column(DateTime(True), nullable=False, server_default=text("now()"))
-    updated_at = Column(DateTime(True), nullable=False, server_default=text("now()"))
+    created_at = Column(DateTime(True), nullable=False, server_default=DEFAULT_DATETIME)
+    updated_at = Column(DateTime(True), nullable=False, server_default=DEFAULT_DATETIME)
 
 
 class LibraryConstructionMethod(Base):
@@ -77,8 +81,8 @@ class LibraryConstructionMethod(Base):
 
     id = Column(Integer, primary_key=True)
     name = Column(String(64))
-    created_at = Column(DateTime(True), nullable=False, server_default=text("now()"))
-    updated_at = Column(DateTime(True), nullable=False, server_default=text("now()"))
+    created_at = Column(DateTime(True), nullable=False, server_default=DEFAULT_DATETIME)
+    updated_at = Column(DateTime(True), nullable=False, server_default=DEFAULT_DATETIME)
 
 
 class Organ(Base):
@@ -86,8 +90,8 @@ class Organ(Base):
 
     id = Column(Integer, primary_key=True)
     name = Column(String(32))
-    created_at = Column(DateTime(True), nullable=False, server_default=text("now()"))
-    updated_at = Column(DateTime(True), nullable=False, server_default=text("now()"))
+    created_at = Column(DateTime(True), nullable=False, server_default=DEFAULT_DATETIME)
+    updated_at = Column(DateTime(True), nullable=False, server_default=DEFAULT_DATETIME)
 
 
 class Species(Base):
@@ -95,8 +99,8 @@ class Species(Base):
 
     id = Column(Integer, primary_key=True)
     name = Column(String(16))
-    created_at = Column(DateTime(True), nullable=False, server_default=text("now()"))
-    updated_at = Column(DateTime(True), nullable=False, server_default=text("now()"))
+    created_at = Column(DateTime(True), nullable=False, server_default=DEFAULT_DATETIME)
+    updated_at = Column(DateTime(True), nullable=False, server_default=DEFAULT_DATETIME)
 
 
 class DataRepository(Base):
@@ -104,8 +108,8 @@ class DataRepository(Base):
 
     id = Column(Integer, primary_key=True)
     name = Column(String(32))
-    created_at = Column(DateTime(True), nullable=False, server_default=text("now()"))
-    updated_at = Column(DateTime(True), nullable=False, server_default=text("now()"))
+    created_at = Column(DateTime(True), nullable=False, server_default=DEFAULT_DATETIME)
+    updated_at = Column(DateTime(True), nullable=False, server_default=DEFAULT_DATETIME)
 
 
 class Contributor(Base):
@@ -116,8 +120,8 @@ class Contributor(Base):
     middle_name = Column(String(16))
     last_name = Column(String(32))
     institution = Column(String(100))
-    created_at = Column(DateTime(True), nullable=False, server_default=text("now()"))
-    updated_at = Column(DateTime(True), nullable=False, server_default=text("now()"))
+    created_at = Column(DateTime(True), nullable=False, server_default=DEFAULT_DATETIME)
+    updated_at = Column(DateTime(True), nullable=False, server_default=DEFAULT_DATETIME)
 
 
 class ExternalAccession(Base):
@@ -127,8 +131,8 @@ class ExternalAccession(Base):
     project_id = Column(ForeignKey("project.id"), nullable=False)
     data_repository_id = Column(ForeignKey("data_repository.id"), nullable=False)
     accession = Column(String(32))
-    created_at = Column(DateTime(True), nullable=False, server_default=text("now()"))
-    updated_at = Column(DateTime(True), nullable=False, server_default=text("now()"))
+    created_at = Column(DateTime(True), nullable=False, server_default=DEFAULT_DATETIME)
+    updated_at = Column(DateTime(True), nullable=False, server_default=DEFAULT_DATETIME)
 
     project = relationship("Project")
     data_repository = relationship("DataRepository")
@@ -140,8 +144,8 @@ class LibraryConstructionMethodJoinProject(Base):
     id = Column(Integer, primary_key=True)
     library_construction_method_id = Column(ForeignKey("library_construction_method.id"), nullable=False)
     project_id = Column(ForeignKey("project.id"), nullable=False)
-    created_at = Column(DateTime(True), nullable=False, server_default=text("now()"))
-    updated_at = Column(DateTime(True), nullable=False, server_default=text("now()"))
+    created_at = Column(DateTime(True), nullable=False, server_default=DEFAULT_DATETIME)
+    updated_at = Column(DateTime(True), nullable=False, server_default=DEFAULT_DATETIME)
 
     library_construction_method = relationship("LibraryConstructionMethod")
     project = relationship("Project")
@@ -153,8 +157,8 @@ class OrganJoinProject(Base):
     id = Column(Integer, primary_key=True)
     organ_id = Column(ForeignKey("organ.id"), nullable=False)
     project_id = Column(ForeignKey("project.id"), nullable=False)
-    created_at = Column(DateTime(True), nullable=False, server_default=text("now()"))
-    updated_at = Column(DateTime(True), nullable=False, server_default=text("now()"))
+    created_at = Column(DateTime(True), nullable=False, server_default=DEFAULT_DATETIME)
+    updated_at = Column(DateTime(True), nullable=False, server_default=DEFAULT_DATETIME)
 
     organ = relationship("Organ")
     project = relationship("Project")
@@ -166,8 +170,8 @@ class SpeciesJoinProject(Base):
     id = Column(Integer, primary_key=True)
     species_id = Column(ForeignKey("species.id"), nullable=False)
     project_id = Column(ForeignKey("project.id"), nullable=False)
-    created_at = Column(DateTime(True), nullable=False, server_default=text("now()"))
-    updated_at = Column(DateTime(True), nullable=False, server_default=text("now()"))
+    created_at = Column(DateTime(True), nullable=False, server_default=DEFAULT_DATETIME)
+    updated_at = Column(DateTime(True), nullable=False, server_default=DEFAULT_DATETIME)
 
     species = relationship("Species")
     project = relationship("Project")
@@ -179,8 +183,8 @@ class ContributorJoinProject(Base):
     id = Column(Integer, primary_key=True)
     contributor_id = Column(ForeignKey("contributor.id"), nullable=False)
     project_id = Column(ForeignKey("project.id"), nullable=False)
-    created_at = Column(DateTime(True), nullable=False, server_default=text("now()"))
-    updated_at = Column(DateTime(True), nullable=False, server_default=text("now()"))
+    created_at = Column(DateTime(True), nullable=False, server_default=DEFAULT_DATETIME)
+    updated_at = Column(DateTime(True), nullable=False, server_default=DEFAULT_DATETIME)
 
     contributor = relationship("Contributor")
     project = relationship("Project")

--- a/dcp_prototype/backend/browser/scripts/create_db.py
+++ b/dcp_prototype/backend/browser/scripts/create_db.py
@@ -12,10 +12,8 @@ from browser.code.common import browser_orm as orm
 
 if __name__ == "__main__":
     engine = create_engine(BrowserDbConfig().database_uri)
-    orm.Base.metadata.bind = engine
-
     print("Dropping tables")
-    orm.Base.metadata.drop_all()
+    orm.Base.metadata.drop_all(engine)
     print("Recreating tables")
     orm.Base.metadata.create_all(engine)
     print([t[0] for t in engine.execute("SHOW TABLES;")])

--- a/dcp_prototype/backend/browser/scripts/load_artifact.py
+++ b/dcp_prototype/backend/browser/scripts/load_artifact.py
@@ -1,6 +1,6 @@
 """
-(2/19/20) Temporary script used to load a preliminary artifact CSV sample.
-          To be succeeded by ETL job(s) from a JSON artifact.
+Loads a JSON artifact from S3 or local file
+and populates the provided SQL-compatible database.
 """
 
 import json
@@ -12,7 +12,7 @@ import boto3
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
-from browser.scripts.mock import mock
+from browser.scripts.mock import mock_data
 
 from browser.code.common.browser_orm import (
     DBSessionMaker,
@@ -30,120 +30,130 @@ from browser.code.common.browser_orm import (
     ContributorJoinProject,
 )
 
-session = DBSessionMaker().session()
 
-s3 = boto3.client("s3")
-s3.download_file("dcp-test-artifacts", "Artifact.Mar18.json", "artifact.json")
+def load_from_artifact(session, path_to_file=None):
+    if not path_to_file:
+        s3 = boto3.client("s3")
+        s3.download_file("dcp-test-artifacts", "Artifact.Mar18.json", "artifact.json")
+        path_to_file = "artifact.json"
 
-with open("artifact.json", "r") as f:
-    data = json.load(f)
-    # augment with mock data (temporary)
+    with open(path_to_file, "r") as f:
+        data = json.load(f)
+        # augment with mock data
+        for project in data["projects"]:
+            for key in mock_data[project["id"]]:
+                project[key] = mock_data[project["id"]][key]
+
+    organs = {}
+    species = {}
+    libraries = {}
+    contributors = {}
+
+    # populate data repository
+    data_repo_names = ["Array Express", "INSDC Project", "GEO Series", "Biostudies"]
+    session.add_all([DataRepository(name=name) for name in data_repo_names])
+    session.commit()
+
+    # populate project
     for project in data["projects"]:
-        for key in mock[project["id"]]:
-            project[key] = mock[project["id"]][key]
-
-organs = {}
-species = {}
-libraries = {}
-contributors = {}
-
-# populate data repository
-data_repo_names = ["Array Express", "INSDC Project", "GEO Series", "Biostudies"]
-session.add_all([DataRepository(name=name) for name in data_repo_names])
-session.commit()
-
-# populate project
-for project in data["projects"]:
-    session.add(
-        Project(
-            id=project["id"],
-            title=project["title"],
-            label=project["label"],
-            description=project["description"],
-            biosample_categories=",".join(project["biosample_categories"]),
-            development_stages=",".join(project["donor_development_stages_at_collection"]),
-            diseases=",".join(project["donor_diseases"]),
-            cell_isolation_methods=",".join(project["cell_isolation_methods"]),
-            cell_types=",".join(project["selected_cell_types"]),
-            cell_count=project["cell_count"],
-            paired_end=",".join([str(e) for e in project["paired_end"]]),
-            nucleic_acid_sources=",".join(project["nucleic_acid_sources"]),
-            input_nucleic_acid_molecules=",".join(project["input_nucleic_acid_molecules"]),
-            publication_title=project["publication_title"],
-            publication_doi=project["publication_doi"],
-            cxg_enabled=project["cxg_enabled"],
-        )
-    )
-    session.commit()
-
-    # populate organ + project join
-    for o in project["organs"]:
-        if o not in organs:
-            organs[o] = len(organs) + 1
-            session.add(Organ(name=o))
-        session.add(OrganJoinProject(organ_id=organs[o], project_id=project["id"]))
-
-    # populate species + project join
-    for s in project["donor_species"]:
-        if s not in species:
-            species[s] = len(species) + 1
-            session.add(Species(name=s))
-        session.add(SpeciesJoinProject(species_id=species[s], project_id=project["id"]))
-
-    # populate library_construction_method + project join
-    for l in project["library_construction_methods"]:
-        if l not in libraries:
-            libraries[l] = len(libraries) + 1
-            session.add(LibraryConstructionMethod(name=l))
         session.add(
-            LibraryConstructionMethodJoinProject(library_construction_method_id=libraries[l], project_id=project["id"])
+            Project(
+                id=project["id"],
+                title=project["title"],
+                label=project["label"],
+                description=project["description"],
+                biosample_categories=",".join(project["biosample_categories"]),
+                development_stages=",".join(project["donor_development_stages_at_collection"]),
+                diseases=",".join(project["donor_diseases"]),
+                cell_isolation_methods=",".join(project["cell_isolation_methods"]),
+                cell_types=",".join(project["selected_cell_types"]),
+                cell_count=project["cell_count"],
+                paired_end=",".join([str(e) for e in project["paired_end"]]),
+                nucleic_acid_sources=",".join(project["nucleic_acid_sources"]),
+                input_nucleic_acid_molecules=",".join(project["input_nucleic_acid_molecules"]),
+                publication_title=project["publication_title"],
+                publication_doi=project["publication_doi"],
+                cxg_enabled=project["cxg_enabled"],
+            )
         )
+        session.commit()
 
-    # populate contributors + project join
-    for c in project["contributors"]:
-        if c["name"] not in contributors:
-            contributors[c["name"]] = {"key": len(contributors) + 1, "institution": c["institution"]}
+        # populate organ + project join
+        for o in project["organs"]:
+            if o not in organs:
+                organs[o] = len(organs) + 1
+                session.add(Organ(name=o))
+            session.add(OrganJoinProject(organ_id=organs[o], project_id=project["id"]))
 
-            names = c["name"].split(",")
-            if len(names) == 3:
-                first = names[0]
-                middle = names[1]
-                last = names[2]
-            elif len(names) == 2:
-                first = names[0]
-                middle = ""
-                last = names[1]
-            else:
-                first, last = c["name"].split(" ")
-                middle = ""
+        # populate species + project join
+        for s in project["donor_species"]:
+            if s not in species:
+                species[s] = len(species) + 1
+                session.add(Species(name=s))
+            session.add(SpeciesJoinProject(species_id=species[s], project_id=project["id"]))
 
-            session.add(Contributor(first_name=first, middle_name=middle, last_name=last, institution=c["institution"]))
-        session.add(ContributorJoinProject(contributor_id=contributors[c["name"]]["key"], project_id=project["id"]))
+        # populate library_construction_method + project join
+        for l in project["library_construction_methods"]:
+            if l not in libraries:
+                libraries[l] = len(libraries) + 1
+                session.add(LibraryConstructionMethod(name=l))
+            session.add(
+                LibraryConstructionMethodJoinProject(
+                    library_construction_method_id=libraries[l], project_id=project["id"]
+                )
+            )
 
-    # populate external accessions
-    for accession in project["array_express_accessions"]:
-        session.add(ExternalAccession(project_id=project["id"], data_repository_id=1, accession=accession))
-    for accession in project["insdc_project_accessions"]:
-        session.add(ExternalAccession(project_id=project["id"], data_repository_id=2, accession=accession))
-    for accession in project["geo_series_accessions"]:
-        session.add(ExternalAccession(project_id=project["id"], data_repository_id=3, accession=accession))
-    for accession in project["biostudies_accessions"]:
-        session.add(ExternalAccession(project_id=project["id"], data_repository_id=4, accession=accession))
-    session.commit()
+        # populate contributors + project join
+        for c in project["contributors"]:
+            if c["name"] not in contributors:
+                contributors[c["name"]] = {"key": len(contributors) + 1, "institution": c["institution"]}
 
-# file
-session.add_all(
-    File(
-        id=file["id"],
-        project_id=file["project_id"],
-        filename=file["filename"],
-        file_format=file["file_format"],
-        file_size=file["file_size"],
-        file_type=file["type"],
-        s3_uri=file["s3_uri"],
+                names = c["name"].split(",")
+                if len(names) == 3:
+                    first = names[0]
+                    middle = names[1]
+                    last = names[2]
+                elif len(names) == 2:
+                    first = names[0]
+                    middle = ""
+                    last = names[1]
+                else:
+                    first, last = c["name"].split(" ")
+                    middle = ""
+
+                session.add(
+                    Contributor(first_name=first, middle_name=middle, last_name=last, institution=c["institution"])
+                )
+            session.add(ContributorJoinProject(contributor_id=contributors[c["name"]]["key"], project_id=project["id"]))
+
+        # populate external accessions
+        for accession in project["array_express_accessions"]:
+            session.add(ExternalAccession(project_id=project["id"], data_repository_id=1, accession=accession))
+        for accession in project["insdc_project_accessions"]:
+            session.add(ExternalAccession(project_id=project["id"], data_repository_id=2, accession=accession))
+        for accession in project["geo_series_accessions"]:
+            session.add(ExternalAccession(project_id=project["id"], data_repository_id=3, accession=accession))
+        for accession in project["biostudies_accessions"]:
+            session.add(ExternalAccession(project_id=project["id"], data_repository_id=4, accession=accession))
+        session.commit()
+
+    # file
+    session.add_all(
+        File(
+            id=file["id"],
+            project_id=file["project_id"],
+            filename=file["filename"],
+            file_format=file["file_format"],
+            file_size=file["file_size"],
+            file_type=file["type"],
+            s3_uri=file["s3_uri"],
+        )
+        for file in data["files"]
     )
-    for file in data["files"]
-)
 
-session.commit()
-session.close()
+    session.commit()
+    session.close()
+
+
+if __name__ == "__main__":
+    load_from_artifact(DBSessionMaker().session())

--- a/dcp_prototype/backend/browser/scripts/mock.py
+++ b/dcp_prototype/backend/browser/scripts/mock.py
@@ -4,7 +4,7 @@ latest artifact schema. Will be deprecated in the next version
 of the artifact.
 """
 
-mock = {
+mock_data = {
     "48c1a1bc-31bd-4420-9d28-9e4e6289eb16": {
         "description": "Significant heterogeneities in gene expression among individual cells are typically "
         "interrogated using single whole cell approaches. However, tissues that have highly "


### PR DESCRIPTION
- When `DEPLOYMENT_STAGE` is set to `test`, an in-memory SQLite database will service all database connections
- These changes propose the deprecation of the deployed `test` environment in favor of [`dev`, `staging`, and `prod`] environments. The `test` moniker will then be reserved for the local environment and unit testing
- [TODO](https://app.zenhub.com/workspaces/dcp2-5e2a191dad828d52cc78b028/issues/chanzuckerberg/dcp-prototype/262): deprecate and shut down deployed `test` environment via Terraform if this proposal sounds good @Bento007 
- Tests covered in #256 

Related to #237 