### PR TITLE
Authorization header allowed

### DIFF
--- a/dcp_prototype/backend/browser/api/app.py
+++ b/dcp_prototype/backend/browser/api/app.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 import chalice
-from chalice import Chalice
+from chalice import Chalice, CORSConfig
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "chalicelib"))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
@@ -12,47 +12,53 @@ from browser.code.common.s3_utils import generate_file_url
 
 app = Chalice(app_name=f"{os.environ['APP_NAME']}-{os.environ['DEPLOYMENT_STAGE']}")
 
+cors_config = CORSConfig(
+    allow_origin="*",
+    max_age=600,
+    allow_credentials=True
+)
+
 
 @app.route("/")
 def index():
     return "render documentation here"
 
 
-@app.route("/projects")
+@app.route("/projects", cors=cors_config)
 def get_projects():
     db = DbUtils()
     projects = db.query_projects()
 
     return chalice.Response(
-        status_code=200, headers={"Content-Type": "application/json", "Access-Control-Allow-Origin": "*"}, body=projects
+        status_code=200, headers={"Content-Type": "application/json"}, body=projects
     )
 
 
-@app.route("/projects/{project_id}")
+@app.route("/projects/{project_id}", cors=cors_config)
 def get_project(project_id):
     db = DbUtils()
     project = db.query_project(project_id)
 
     return chalice.Response(
         status_code=200 if project else 404,
-        headers={"Content-Type": "application/json", "Access-Control-Allow-Origin": "*"},
+        headers={"Content-Type": "application/json"},
         body=project,
     )
 
 
-@app.route("/projects/{project_id}/files")
+@app.route("/projects/{project_id}/files", cors=cors_config)
 def get_project_files(project_id):
     db = DbUtils()
     files = db.query_downloadable_project_files(project_id)
 
     return chalice.Response(
         status_code=200 if files else 404,
-        headers={"Content-Type": "application/json", "Access-Control-Allow-Origin": "*"},
+        headers={"Content-Type": "application/json"},
         body=files,
     )
 
 
-@app.route("/files/{file_id}")
+@app.route("/files/{file_id}", cors=cors_config)
 def get_file(file_id):
     db = DbUtils()
     file = db.query_file(file_id)
@@ -65,6 +71,6 @@ def get_file(file_id):
 
     return chalice.Response(
         status_code=200 if file else 404,
-        headers={"Content-Type": "application/json", "Access-Control-Allow-Origin": "*"},
+        headers={"Content-Type": "application/json"},
         body={"url": download_url},
     )

--- a/dcp_prototype/backend/browser/api/app.py
+++ b/dcp_prototype/backend/browser/api/app.py
@@ -12,11 +12,7 @@ from browser.code.common.s3_utils import generate_file_url
 
 app = Chalice(app_name=f"{os.environ['APP_NAME']}-{os.environ['DEPLOYMENT_STAGE']}")
 
-cors_config = CORSConfig(
-    allow_origin="*",
-    max_age=600,
-    allow_credentials=True
-)
+cors_config = CORSConfig(allow_origin="*", max_age=600, allow_credentials=True)
 
 
 @app.route("/")
@@ -29,9 +25,7 @@ def get_projects():
     db = DbUtils()
     projects = db.query_projects()
 
-    return chalice.Response(
-        status_code=200, headers={"Content-Type": "application/json"}, body=projects
-    )
+    return chalice.Response(status_code=200, headers={"Content-Type": "application/json"}, body=projects)
 
 
 @app.route("/projects/{project_id}", cors=cors_config)
@@ -40,9 +34,7 @@ def get_project(project_id):
     project = db.query_project(project_id)
 
     return chalice.Response(
-        status_code=200 if project else 404,
-        headers={"Content-Type": "application/json"},
-        body=project,
+        status_code=200 if project else 404, headers={"Content-Type": "application/json"}, body=project,
     )
 
 
@@ -52,9 +44,7 @@ def get_project_files(project_id):
     files = db.query_downloadable_project_files(project_id)
 
     return chalice.Response(
-        status_code=200 if files else 404,
-        headers={"Content-Type": "application/json"},
-        body=files,
+        status_code=200 if files else 404, headers={"Content-Type": "application/json"}, body=files,
     )
 
 
@@ -70,7 +60,5 @@ def get_file(file_id):
         download_url = generate_file_url(file_prefix)
 
     return chalice.Response(
-        status_code=200 if file else 404,
-        headers={"Content-Type": "application/json"},
-        body={"url": download_url},
+        status_code=200 if file else 404, headers={"Content-Type": "application/json"}, body={"url": download_url},
     )


### PR DESCRIPTION
- modified chalice application to Allowing Origin "*" using chalice.CORSConfig
- this will allow us to send the auth token to the backend