### PR TITLE
Remove functional tests from push tests

### DIFF
--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -40,25 +40,3 @@ jobs:
       run: |
         make unit-test
         bash <(curl -s https://codecov.io/bash) -cF backend,python,unitTest
-
-  functional-test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.7
-      - name: Python cache
-        uses: actions/cache@v1
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - name: Install dependencies
-        run: pip install -r requirements-dev.txt
-      - name: Functional tests
-        run: |
-          source environment.test
-          make functional-test

--- a/README.md
+++ b/README.md
@@ -12,13 +12,15 @@ Environment variables used for configuration:
 * `DEPLOYMENT_STAGE` - set this value to target a specific deployment stage for deploying code and infrastructure.
 
 ### Testing
-Set the `DEPLOYMENT_STAGE` environment variable to `test`
-
 Install dependencies `pip install -r requirements-dev.txt`
 
-Commands and their uses:
-* `make unit-test` - runs all unit tests
-* `make functional-test` - runs all functional tests
+Unit tests:
+* Set `DEPLOYMENT_STAGE=test`
+* Run `make unit-test`
+
+Functional tests:
+* Set `DEPLOYMENT_STAGE` to a valid deployed environment (`dev`)
+* Run `make functional-test`
 
 ### Code formatting and linting
 

--- a/dcp_prototype/backend/browser/README.md
+++ b/dcp_prototype/backend/browser/README.md
@@ -36,11 +36,16 @@ To redeploy your app after updating, run `make deploy` again. To undeploy the ap
 run `make destroy`.
 
 ## Testing
-Set the `DEPLOYMENT_STAGE` environment variable to `test`.
+Tests are run in the top level directory `dcp-prototype`
 
-In the top level directory `dcp-prototype`:
-- `pip install -r requirements-dev.txt`
+Install dev requirements `pip install -r requirements-dev.txt`
+
+Unit tests:
+- Set the `DEPLOYMENT_STAGE` environment variable to `test`
 - Run `make unit-test` to run unit tests
+
+Functional tests:
+- Set the `DEPLOYMENT_STAGE` environment variable to a valid deployed environment (`dev`)
 - Run `make functional-test` to run functional tests
 
 ## Managing the Lambda IAM role and assume role policy


### PR DESCRIPTION
Functional tests require an E2E deployment which is either not possible or overly complicated to perform for every development branch. These tests will be reintroduced in CI/CD as smoketests following a merge and deployment to `dev`, `staging` and `prod`. Until then, they will remain a useful tool to use on developer environments.