### PR TITLE
Adding local-server make recipe 

### DIFF
--- a/dcp_prototype/backend/browser/Makefile
+++ b/dcp_prototype/backend/browser/Makefile
@@ -16,3 +16,7 @@ clean:
 .PHONY: package
 package:
 	$(MAKE) package -C api
+
+.PHONY: local-server
+local-server:
+	$(MAKE)  local-server -C api

--- a/dcp_prototype/backend/browser/api/Makefile
+++ b/dcp_prototype/backend/browser/api/Makefile
@@ -45,3 +45,6 @@ build-chalice-config:
 	cd .chalice; jq .stages.$(DEPLOYMENT_STAGE).tags.service=env.APP_NAME config.json | sponge config.json
 	cd .chalice; jq .stages.$(DEPLOYMENT_STAGE).api_gateway_stage=env.DEPLOYMENT_STAGE config.json | sponge config.json
 
+.PHONY: local-server
+local-server: package
+	python local_server.py

--- a/dcp_prototype/backend/browser/api/local_server.py
+++ b/dcp_prototype/backend/browser/api/local_server.py
@@ -24,6 +24,7 @@ parser.add_argument("--log-level",
                     default=logging.DEBUG)
 args = parser.parse_args()
 logging.basicConfig(level=args.log_level, stream=sys.stderr)
+logging.getLogger('botocore').setLevel(logging.INFO)
 factory = CLIFactory(project_dir=args.project_dir, debug=args.debug)
 
 # The following code snippet is basically stolen from chalice/__init__py:run_local_server

--- a/dcp_prototype/backend/browser/api/local_server.py
+++ b/dcp_prototype/backend/browser/api/local_server.py
@@ -27,8 +27,10 @@ logging.basicConfig(level=args.log_level, stream=sys.stderr)
 logging.getLogger("botocore").setLevel(logging.INFO)
 factory = CLIFactory(project_dir=args.project_dir, debug=args.debug)
 
+os.environ["DEPLOYMENT_STAGE"] = os.getenv("DEPLOYMENT_STAGE", "test")
+
 # The following code snippet is basically stolen from chalice/__init__py:run_local_server
-config = factory.create_config_obj(chalice_stage_name=os.getenv("DEPLOYMENT_STAGE"))
+config = factory.create_config_obj(chalice_stage_name=os.environ["DEPLOYMENT_STAGE"])
 app_obj = factory.load_chalice_app()
 server = factory.create_local_server(app_obj=app_obj, config=config, host=args.host, port=args.port)
 server.serve_forever()

--- a/dcp_prototype/backend/browser/api/local_server.py
+++ b/dcp_prototype/backend/browser/api/local_server.py
@@ -14,23 +14,21 @@ from chalice.cli import CLIFactory
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument("--host", default="localhost")
 parser.add_argument("--port", type=int, default=5000)
-parser.add_argument("--no-debug", dest="debug", action="store_false",
-                    help="Disable Chalice/Connexion/Flask debug mode")
-parser.add_argument("--project-dir", help=argparse.SUPPRESS,
-                    default=os.path.join(os.path.dirname(__file__)))
-parser.add_argument("--log-level",
-                    help=str([logging.getLevelName(i) for i in range(0, 60, 10)]),
-                    choices={logging.getLevelName(i) for i in range(0, 60, 10)},
-                    default=logging.DEBUG)
+parser.add_argument("--no-debug", dest="debug", action="store_false", help="Disable Chalice/Connexion/Flask debug mode")
+parser.add_argument("--project-dir", help=argparse.SUPPRESS, default=os.path.join(os.path.dirname(__file__)))
+parser.add_argument(
+    "--log-level",
+    help=str([logging.getLevelName(i) for i in range(0, 60, 10)]),
+    choices={logging.getLevelName(i) for i in range(0, 60, 10)},
+    default=logging.DEBUG,
+)
 args = parser.parse_args()
 logging.basicConfig(level=args.log_level, stream=sys.stderr)
-logging.getLogger('botocore').setLevel(logging.INFO)
+logging.getLogger("botocore").setLevel(logging.INFO)
 factory = CLIFactory(project_dir=args.project_dir, debug=args.debug)
 
 # The following code snippet is basically stolen from chalice/__init__py:run_local_server
-config = factory.create_config_obj(
-    chalice_stage_name=os.getenv('DEPLOYMENT_STAGE')
-)
+config = factory.create_config_obj(chalice_stage_name=os.getenv("DEPLOYMENT_STAGE"))
 app_obj = factory.load_chalice_app()
 server = factory.create_local_server(app_obj=app_obj, config=config, host=args.host, port=args.port)
 server.serve_forever()

--- a/dcp_prototype/backend/browser/api/local_server.py
+++ b/dcp_prototype/backend/browser/api/local_server.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+"""
+Entry point for starting a local test API server.
+"""
+
+import argparse
+import logging
+import os
+import sys
+
+from chalice.cli import CLIFactory
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("--host", default="localhost")
+parser.add_argument("--port", type=int, default=5000)
+parser.add_argument("--no-debug", dest="debug", action="store_false",
+                    help="Disable Chalice/Connexion/Flask debug mode")
+parser.add_argument("--project-dir", help=argparse.SUPPRESS,
+                    default=os.path.join(os.path.dirname(__file__)))
+parser.add_argument("--log-level",
+                    help=str([logging.getLevelName(i) for i in range(0, 60, 10)]),
+                    choices={logging.getLevelName(i) for i in range(0, 60, 10)},
+                    default=logging.DEBUG)
+args = parser.parse_args()
+logging.basicConfig(level=args.log_level, stream=sys.stderr)
+factory = CLIFactory(project_dir=args.project_dir, debug=args.debug)
+
+# The following code snippet is basically stolen from chalice/__init__py:run_local_server
+config = factory.create_config_obj(
+    chalice_stage_name=os.getenv('DEPLOYMENT_STAGE')
+)
+app_obj = factory.load_chalice_app()
+server = factory.create_local_server(app_obj=app_obj, config=config, host=args.host, port=args.port)
+server.serve_forever()

--- a/dcp_prototype/backend/browser/requirements-dev.txt
+++ b/dcp_prototype/backend/browser/requirements-dev.txt
@@ -1,4 +1,3 @@
-chalice==1.12.0
 furl
 -r requirements.txt
 -r ../../../requirements-dev.txt

--- a/dcp_prototype/frontend/.env.development
+++ b/dcp_prototype/frontend/.env.development
@@ -4,5 +4,5 @@ AUTH0_DOMAIN=czi-single-cell.auth0.com
 AUTH0_CLIENTID=68D0YqRJmwE6MMCV9zxr5bDBjfctDFBi
 AUTH0_CALLBACK=http://localhost:8000/
 
-API_URL=https://u5j1wa9u5i.execute-api.us-east-1.amazonaws.com/dev
+API_URL=http://localhost:5000
 CXG_URL=http://cellxgene-dev.us-west-2.elasticbeanstalk.com

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@ moto
 pytest
 requests>=2.22.0
 sqlalchemy
+chalice==1.12.0


### PR DESCRIPTION
Adding local-server make recipe to simplify testing of the frontend with a local browser backend.