### PR TITLE
Fixes for #246 and #249

### DIFF
--- a/dcp_prototype/frontend/src/components/exploreData.js
+++ b/dcp_prototype/frontend/src/components/exploreData.js
@@ -14,11 +14,11 @@ const ExploreData = ({ project, files, isAuthenticated }) => {
   return (
   <Box sx={{
     mb: 2,
-    maxWidth: 0
+    maxWidth: 1100
   }}>
     <Flex sx={{
       mb: 1,
-      maxWidth: 0
+      maxWidth: 1100
     }}>
       <StyledButton label="Download matrix"
                     disabled={!matrixAvailable}

--- a/dcp_prototype/frontend/src/components/exploreData.js
+++ b/dcp_prototype/frontend/src/components/exploreData.js
@@ -14,11 +14,11 @@ const ExploreData = ({ project, files, isAuthenticated }) => {
   return (
   <Box sx={{
     mb: 2,
-    maxWidth: 1100
+    maxWidth: 0
   }}>
     <Flex sx={{
       mb: 1,
-      maxWidth: 1100
+      maxWidth: 0
     }}>
       <StyledButton label="Download matrix"
                     disabled={!matrixAvailable}

--- a/dcp_prototype/frontend/src/components/exploreData.js
+++ b/dcp_prototype/frontend/src/components/exploreData.js
@@ -12,8 +12,14 @@ const ExploreData = ({ project, files, isAuthenticated }) => {
     const { getTokenSilently } = useAuth0()
 
   return (
-  <Box sx={{mb: 2}}>
-    <Flex sx={{mb: 1}}>
+  <Box sx={{
+    mb: 2,
+    maxWidth: 1100
+  }}>
+    <Flex sx={{
+      mb: 1,
+      maxWidth: 1100
+    }}>
       <StyledButton label="Download matrix"
                     disabled={!matrixAvailable}
                     onclick={() => getTokenSilently().then(accessToken =>

--- a/dcp_prototype/frontend/src/components/footer.js
+++ b/dcp_prototype/frontend/src/components/footer.js
@@ -16,7 +16,7 @@ const Header = ({ siteTitle }) => {
           justifyContent: "space-between",
           fontWeight: 700,
           margin: `0 auto`,
-          maxWidth: "1400px",
+          maxWidth: 1,
           padding: [3],
           paddingLeft: 5,
         }}

--- a/dcp_prototype/frontend/src/components/footer.js
+++ b/dcp_prototype/frontend/src/components/footer.js
@@ -16,7 +16,7 @@ const Header = ({ siteTitle }) => {
           justifyContent: "space-between",
           fontWeight: 700,
           margin: `0 auto`,
-          maxWidth: "1100px",
+          maxWidth: "1400px",
           padding: [3],
           paddingLeft: 5,
         }}

--- a/dcp_prototype/frontend/src/components/header.js
+++ b/dcp_prototype/frontend/src/components/header.js
@@ -18,7 +18,7 @@ const Header = ({ siteTitle }) => {
           justifyContent: "space-between",
           fontWeight: 700,
           margin: `0 auto`,
-          maxWidth: "1400px",
+          maxWidth: 1,
           paddingTop: 0,
           paddingBottom: 0,
           paddingLeft: 5,

--- a/dcp_prototype/frontend/src/components/header.js
+++ b/dcp_prototype/frontend/src/components/header.js
@@ -18,7 +18,7 @@ const Header = ({ siteTitle }) => {
           justifyContent: "space-between",
           fontWeight: 700,
           margin: `0 auto`,
-          maxWidth: "1100px",
+          maxWidth: "1400px",
           paddingTop: 0,
           paddingBottom: 0,
           paddingLeft: 5,

--- a/dcp_prototype/frontend/src/components/layout.js
+++ b/dcp_prototype/frontend/src/components/layout.js
@@ -31,7 +31,7 @@ const Layout = ({ children }) => {
       <div
         style={{
           margin: `0 auto`,
-          maxWidth: 1100,
+          maxWidth: 1400,
           minHeight:
             // "100vh", /* for now. better: height minus footer, or go to sticky */
             `calc(100vh - 85px - 60px - 48px)`, // height minus footer, minus header, minus margin between header and "Explore Data"; only way I coudl get footer to level with bottom of screen

--- a/dcp_prototype/frontend/src/components/projectOverview.js
+++ b/dcp_prototype/frontend/src/components/projectOverview.js
@@ -53,7 +53,7 @@ const ProjectOverview = ({ project, files, isAuthenticated }) => {
         sx={{
           fontSize: [1],
           mb: [4],
-          maxWidth: 1100
+          maxWidth: 0
         }}
       >
         <Box sx={{

--- a/dcp_prototype/frontend/src/components/projectOverview.js
+++ b/dcp_prototype/frontend/src/components/projectOverview.js
@@ -13,15 +13,18 @@ const ProjectOverview = ({ project, files, isAuthenticated }) => {
   )
   const contributors = !project.contributors.length ? null : (
       <Flex>
-        <Box>
+        <Box
+          sx={{
+            width: "50%"
+          }}>
           <Heading as="h6" sx={{ mb: [2] }}>
             Contributors
           </Heading>
           {project.contributors.map(c => <Text key={c.name}>{c.name}</Text>)}
         </Box>
         <Box sx={{
-          ml: [2],
-          marginLeft: [6]
+          marginLeft: [6],
+          width: "50%"
         }}>
           <Heading as="h6" sx={{ mb: [2] }}>
             Institutions
@@ -32,7 +35,10 @@ const ProjectOverview = ({ project, files, isAuthenticated }) => {
   )
   return (
     <Box>
-      <Heading as="h3" sx={{ mb: 4 }}>
+      <Heading as="h3" sx={{
+        mb: 4,
+        maxWidth: 0
+      }}>
         {project.title}
       </Heading>
       {!project ? null : (
@@ -47,7 +53,7 @@ const ProjectOverview = ({ project, files, isAuthenticated }) => {
         sx={{
           fontSize: [1],
           mb: [4],
-          maxWidth: 1100
+          maxWidth: 0
         }}
       >
         <Box sx={{

--- a/dcp_prototype/frontend/src/components/projectOverview.js
+++ b/dcp_prototype/frontend/src/components/projectOverview.js
@@ -23,8 +23,8 @@ const ProjectOverview = ({ project, files, isAuthenticated }) => {
           {project.contributors.map(c => <Text key={c.name}>{c.name}</Text>)}
         </Box>
         <Box sx={{
-          marginLeft: [6],
-          width: "50%"
+          ml: [2],
+          marginLeft: [6]
         }}>
           <Heading as="h6" sx={{ mb: [2] }}>
             Institutions
@@ -53,7 +53,7 @@ const ProjectOverview = ({ project, files, isAuthenticated }) => {
         sx={{
           fontSize: [1],
           mb: [4],
-          maxWidth: 0
+          maxWidth: 1100
         }}
       >
         <Box sx={{

--- a/dcp_prototype/frontend/src/components/projectOverview.js
+++ b/dcp_prototype/frontend/src/components/projectOverview.js
@@ -19,7 +19,10 @@ const ProjectOverview = ({ project, files, isAuthenticated }) => {
           </Heading>
           {project.contributors.map(c => <Text key={c.name}>{c.name}</Text>)}
         </Box>
-        <Box sx={{ml: [2]}}>
+        <Box sx={{
+          ml: [2],
+          marginLeft: [6]
+        }}>
           <Heading as="h6" sx={{ mb: [2] }}>
             Institutions
           </Heading>
@@ -44,9 +47,14 @@ const ProjectOverview = ({ project, files, isAuthenticated }) => {
         sx={{
           fontSize: [1],
           mb: [4],
+          maxWidth: 1100
         }}
       >
-        <Box sx={{ maxWidth: "30em", mr: 5 }}>
+        <Box sx={{
+          // maxWidth: "30em",
+          maxWidth: "60%",
+          mr: 5
+        }}>
           <Box sx={{ mb: [4] }}>
             <Heading as="h6" sx={{ mb: [2] }}>
               Description
@@ -61,13 +69,13 @@ const ProjectOverview = ({ project, files, isAuthenticated }) => {
             <Heading as="h6" sx={{ mb: [2] }}>
               Project Details
             </Heading>
-            <Text>Species: {project.species.join(", ")}</Text>
-            <Text>Organs: {project.organs.join(", ")}</Text>
-            <Text>Sample Categories: {project.biosample_categories.join(", ")}</Text>
-            <Text>Disease Status: {project.diseases.join(", ")}</Text>
-            <Text>Library Construction methods: {project.assays.join(", ")}</Text>
-            <Text>Paired end: {project.paired_end.join(", ")}</Text>
-            <Text>Cell count estimate: {project.cell_count}</Text>
+            <Text><strong>Species: </strong>{project.species.join(", ")}</Text>
+            <Text><strong>Organs: </strong>{project.organs.join(", ")}</Text>
+            <Text><strong>Sample Categories: </strong>{project.biosample_categories.join(", ")}</Text>
+            <Text><strong>Disease Status: </strong>{project.diseases.join(", ")}</Text>
+            <Text><strong>Library Construction methods: </strong>{project.assays.join(", ")}</Text>
+            <Text><strong>Paired end: </strong>{project.paired_end.join(", ")}</Text>
+            <Text><strong>Cell count estimate: </strong>{project.cell_count}</Text>
           </Box>
         </Flex>
       </Flex>

--- a/dcp_prototype/frontend/src/components/projectsList.js
+++ b/dcp_prototype/frontend/src/components/projectsList.js
@@ -13,7 +13,6 @@ const ProjectsList = ({ projects }) => {
             sx={{
               fontSize: [1],
               paddingBottom: [5],
-              paddingTop: "10px",
               borderTop: "#e5e5e5 1px solid",
             }}
             key={project.id}
@@ -32,7 +31,12 @@ const ProjectsList = ({ projects }) => {
             >
               <Flex sx={{ flexDirection: "column" }}>
                 {project.organs.map(organ=> (
-                  <Box key={organ}>{organ.charAt(0).toUpperCase() + organ.substring(1)}</Box>
+                  <Box key={organ}
+                  sx={{
+                    paddingTop: "10px",
+                    lineHeight: "1.5",
+                  }}
+                  >{organ.charAt(0).toUpperCase() + organ.substring(1)}</Box>
                 ))}
               </Flex>
             </Box>
@@ -50,7 +54,12 @@ const ProjectsList = ({ projects }) => {
             >
               <Flex sx={{ flexDirection: "column" }}>
                 {project.assays.map(assay => (
-                  <Box key={assay}>{assay}</Box>
+                  <Box key={assay}
+                  sx={{
+                    paddingTop: "10px",
+                    lineHeight: "1.5",
+                  }}
+                  >{assay}</Box>
                 ))}
               </Flex>
             </Box>
@@ -68,7 +77,12 @@ const ProjectsList = ({ projects }) => {
             >
               <Flex sx={{ flexDirection: "column" }}>
                 {project.species.map(species => (
-                  <Box key={species}>{species}</Box>
+                  <Box key={species}
+                  sx={{
+                    paddingTop: "10px",
+                    lineHeight: "1.5",
+                  }}
+                  >{species}</Box>
                 ))}
               </Flex>
             </Box>
@@ -83,6 +97,8 @@ const ProjectsList = ({ projects }) => {
                 overflow: "hidden", // Or flex might break
                 listStyle: "none",
                 textAlign: "right", // since it holds numbers
+                paddingTop: "10px",
+                lineHeight: "1.5",
               }}
             >
               {project.cell_count || "Unspecified"}
@@ -96,6 +112,8 @@ const ProjectsList = ({ projects }) => {
                 width: `36%`, // Narrower so Project Name has more width; account for right margin of "6" in array = 48px
                 overflow: "hidden", // Or flex might break
                 listStyle: "none",
+                paddingTop: "10px",
+                lineHeight: "1.5",
               }}
             >
               <Link to={`/project/?id=${project.id}`}>{project.title}</Link>

--- a/dcp_prototype/frontend/src/components/theme.js
+++ b/dcp_prototype/frontend/src/components/theme.js
@@ -1,5 +1,6 @@
 export default {
   space: [12, 14, 16, 20, 24, 32, 48, 64, 96],
+  maxWidth: [1100, 1400],
   fonts: {
     body: "Montserrat",
     heading: "Roboto",

--- a/dcp_prototype/frontend/src/pages/project.js
+++ b/dcp_prototype/frontend/src/pages/project.js
@@ -49,7 +49,13 @@ const SecondPage = props => {
   return (
     <Layout>
       <SEO title="Projects"/>
-      <Heading as="h1" sx={{ mb: 5, mt: 6 }}>
+      <Heading as="h1" sx={{
+        mb: 5,
+        mt: 6,
+        maxWidth: 1100,
+        marginLeft: "auto",
+        marginRight: "auto"
+       }}>
         Explore Project
       </Heading>
       <Flex sx={{justifyContent: 'center'}}>

--- a/dcp_prototype/frontend/src/pages/project.js
+++ b/dcp_prototype/frontend/src/pages/project.js
@@ -52,7 +52,7 @@ const SecondPage = props => {
       <Heading as="h1" sx={{
         mb: 5,
         mt: 6,
-        maxWidth: 0,
+        maxWidth: 1100,
         marginLeft: "auto",
         marginRight: "auto"
        }}>

--- a/dcp_prototype/frontend/src/pages/project.js
+++ b/dcp_prototype/frontend/src/pages/project.js
@@ -52,7 +52,7 @@ const SecondPage = props => {
       <Heading as="h1" sx={{
         mb: 5,
         mt: 6,
-        maxWidth: 1100,
+        maxWidth: 0,
         marginLeft: "auto",
         marginRight: "auto"
        }}>


### PR DESCRIPTION
Better legibility for organ and assay names that run over one line (also increased table max width to make this happen less often) + fixing spacing issues for "Diabetic Nephropathy..." project page. I also added a bit of styling to the project page to differentiate the labels from their values.