### PR TITLE
Adding JWT Token verify to browser backend

### DIFF
--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -25,8 +25,8 @@ jobs:
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets. AWS_CZI_HCA_DEV_CI_KEY }}
-        aws-secret-access-key: ${{ secrets.AWS_CZI_HCA_DEV_CI_SECRET }}
+        aws-access-key-id: ${{ secrets.GATSBY_AWS_ACCESS_KEY }}
+        aws-secret-access-key: ${{ secrets.GATSBY_AWS_SECRET_ACCESS_KEY }}
         aws-region: us-east-1
     - uses: actions/checkout@v2
     - name: Set up Python 3.7

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -25,8 +25,8 @@ jobs:
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-access-key-id: ${{ secrets.AWS_CZI_HCA_DEV_CI_KEY }}
+        aws-secret-access-key: ${{ secrets.AWS_CZI_HCA_DEV_CI_SECRET }}
         aws-region: us-east-1
     - uses: actions/checkout@v2
     - name: Set up Python 3.7

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -22,6 +22,12 @@ jobs:
   unit-test:
     runs-on: ubuntu-latest
     steps:
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets. AWS_CZI_HCA_DEV_CI_KEY }}
+        aws-secret-access-key: ${{ secrets.AWS_CZI_HCA_DEV_CI_SECRET }}
+        aws-region: us-east-1
     - uses: actions/checkout@v2
     - name: Set up Python 3.7
       uses: actions/setup-python@v1

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -25,8 +25,8 @@ jobs:
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY}}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-east-1
     - uses: actions/checkout@v2
     - name: Set up Python 3.7

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -25,8 +25,8 @@ jobs:
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.GATSBY_AWS_ACCESS_KEY }}
-        aws-secret-access-key: ${{ secrets.GATSBY_AWS_SECRET_ACCESS_KEY }}
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY}}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
         aws-region: us-east-1
     - uses: actions/checkout@v2
     - name: Set up Python 3.7

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -25,8 +25,8 @@ jobs:
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.AWS_CZI_HCA_DEV_CI_KEY }}
-        aws-secret-access-key: ${{ secrets.AWS_CZI_HCA_DEV_CI_SECRET }}
+        aws-access-key-id: ${{ secrets.GATSBY_AWS_ACCESS_KEY }}
+        aws-secret-access-key: ${{ secrets.GATSBY_AWS_SECRET_ACCESS_KEY }}
         aws-region: us-east-1
     - uses: actions/checkout@v2
     - name: Set up Python 3.7

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -25,8 +25,8 @@ jobs:
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.GATSBY_AWS_ACCESS_KEY }}
-        aws-secret-access-key: ${{ secrets.GATSBY_AWS_SECRET_ACCESS_KEY }}
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-east-1
     - uses: actions/checkout@v2
     - name: Set up Python 3.7

--- a/dcp_prototype/backend/browser/api/app.py
+++ b/dcp_prototype/backend/browser/api/app.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from functools import wraps
 
 import chalice
 from chalice import Chalice, CORSConfig
@@ -9,10 +10,28 @@ sys.path.insert(0, pkg_root)  # noqa
 
 from browser.code.common.db_utils import DbUtils
 from browser.code.common.s3_utils import generate_file_url
+from browser.code.common.authorizer import assert_authorized
 
 app = Chalice(app_name=f"{os.environ['APP_NAME']}-{os.environ['DEPLOYMENT_STAGE']}")
 
 cors_config = CORSConfig(allow_origin="*", max_age=600, allow_credentials=True)
+
+
+def requires_auth():
+    """
+    A decorator for assert_authorized
+    :return: 401 or the original function response.
+    """
+
+    def decorate(func):
+        @wraps(func)
+        def call(*args, **kwargs):
+            assert_authorized(app.current_request.headers)
+            return func(*args, **kwargs)
+
+        return call
+
+    return decorate
 
 
 @app.route("/")
@@ -39,17 +58,18 @@ def get_project(project_id: str):
 
 
 @app.route("/projects/{project_id}/files", cors=cors_config)
-def get_project_files(project_id: str):
+@requires_auth()
+def get_project_files(project_id: str, **kwags):
     db = DbUtils()
     files = db.query_downloadable_project_files(project_id)
-
     return chalice.Response(
         status_code=200 if files else 404, headers={"Content-Type": "application/json"}, body=files,
     )
 
 
 @app.route("/files/{file_id}", cors=cors_config)
-def get_file(file_id: str):
+@requires_auth()
+def get_file(file_id: str, **kwags):
     db = DbUtils()
     file = db.query_file(file_id)
 

--- a/dcp_prototype/backend/browser/api/app.py
+++ b/dcp_prototype/backend/browser/api/app.py
@@ -59,7 +59,7 @@ def get_project(project_id: str):
 
 @app.route("/projects/{project_id}/files", cors=cors_config)
 @requires_auth()
-def get_project_files(project_id: str, **kwags):
+def get_project_files(project_id: str):
     db = DbUtils()
     files = db.query_downloadable_project_files(project_id)
     return chalice.Response(
@@ -69,7 +69,7 @@ def get_project_files(project_id: str, **kwags):
 
 @app.route("/files/{file_id}", cors=cors_config)
 @requires_auth()
-def get_file(file_id: str, **kwags):
+def get_file(file_id: str):
     db = DbUtils()
     file = db.query_file(file_id)
 

--- a/dcp_prototype/backend/browser/api/requirements.txt
+++ b/dcp_prototype/backend/browser/api/requirements.txt
@@ -1,3 +1,5 @@
 dcplib==3.12.0
 PyMySQL==0.9.3
 SQLAlchemy==1.3.13
+requests>=2.22.0
+python-jose[cryptography]>=3.1.0

--- a/dcp_prototype/backend/browser/code/common/authorizer.py
+++ b/dcp_prototype/backend/browser/code/common/authorizer.py
@@ -3,7 +3,7 @@ from functools import lru_cache
 
 import requests
 from chalice import UnauthorizedError
-from jose import jwt
+from jose import jwt, JWTError
 
 USERINFO_ENDPOINT = "https://czi-single-cell.auth0.com/userinfo"
 
@@ -16,7 +16,10 @@ def assert_authorized(headers: dict):
     """Determines if the Access Token is valid
     """
     token = get_token_auth_header(headers)
-    unverified_header = jwt.get_unverified_header(token)
+    try:
+        unverified_header = jwt.get_unverified_header(token)
+    except JWTError:
+        raise UnauthorizedError(msg="Unable to parse authentication token.")
     public_keys = get_public_keys(AUTH0_DOMAIN)
     public_key = public_keys.get(unverified_header["kid"])
     if public_key:

--- a/dcp_prototype/backend/browser/code/common/authorizer.py
+++ b/dcp_prototype/backend/browser/code/common/authorizer.py
@@ -8,7 +8,7 @@ from jose import jwt, JWTError
 USERINFO_ENDPOINT = "https://czi-single-cell.auth0.com/userinfo"
 
 AUTH0_DOMAIN = "czi-single-cell.auth0.com"
-API_AUDIENCE = "https://browser-api.dev.single-cell.czi.technology"
+API_AUDIENCE = f"https://browser-api.{os.environ['DEPLOYMENT_STAGE']}.single-cell.czi.technology"
 ALGORITHMS = ["RS256"]
 
 

--- a/dcp_prototype/backend/browser/code/common/authorizer.py
+++ b/dcp_prototype/backend/browser/code/common/authorizer.py
@@ -38,7 +38,7 @@ def assert_authorized(headers: dict) -> dict:
         except Exception:
             raise UnauthorizedError(msg="Unable to parse authentication token.")
 
-        if os.getenv("DEPLOYMENT_STAGE", "test").lower() != "test":
+        if os.getenv("DEPLOYMENT_STAGE", "test").lower() not in ["test", "dev"]:
             payload["userinfo"] = get_userinfo()
 
         return payload

--- a/dcp_prototype/backend/browser/code/common/authorizer.py
+++ b/dcp_prototype/backend/browser/code/common/authorizer.py
@@ -31,7 +31,7 @@ def assert_authorized(headers: dict):
             raise UnauthorizedError(msg="token is expired")
         except jwt.JWTClaimsError:
             raise UnauthorizedError(msg="incorrect claims, please check the audience and issuer")
-        except Exception as ex:
+        except Exception:
             raise UnauthorizedError(msg="Unable to parse authentication token.")
 
         if os.getenv("DEPLOYMENT_STAGE", "test").lower() != "test":

--- a/dcp_prototype/backend/browser/code/common/authorizer.py
+++ b/dcp_prototype/backend/browser/code/common/authorizer.py
@@ -1,0 +1,91 @@
+import os
+from functools import lru_cache
+
+import requests
+from chalice import UnauthorizedError
+from jose import jwt
+
+USERINFO_ENDPOINT = "https://czi-single-cell.auth0.com/userinfo"
+
+AUTH0_DOMAIN = "czi-single-cell.auth0.com"
+API_AUDIENCE = "https://browser-api.dev.single-cell.czi.technology"
+ALGORITHMS = ["RS256"]
+
+
+def assert_authorized(headers: dict):
+    """Determines if the Access Token is valid
+    """
+    token = get_token_auth_header(headers)
+    unverified_header = jwt.get_unverified_header(token)
+    public_keys = get_public_keys(AUTH0_DOMAIN)
+    public_key = public_keys.get(unverified_header["kid"])
+    if public_key:
+        try:
+            payload = jwt.decode(
+                token, public_key, algorithms=ALGORITHMS, audience=API_AUDIENCE,
+                issuer=f"https://{AUTH0_DOMAIN}/"
+            )
+        except jwt.ExpiredSignatureError:
+            raise UnauthorizedError(msg="token is expired")
+        except jwt.JWTClaimsError:
+            raise UnauthorizedError(
+                msg="incorrect claims, please check the audience and issuer")
+        except Exception as ex:
+            raise UnauthorizedError(msg="Unable to parse authentication token.")
+
+        if os.getenv("DEPLOYMENT_STAGE", "test").lower() != "test":
+            payload['userinfo'] = get_userinfo()
+
+        return payload
+    raise UnauthorizedError(msg="Unable to find appropriate key")
+
+
+def get_token_auth_header(headers: dict) -> str:
+    """Obtains the Access Token from the Authorization Header
+    """
+    auth_header = headers.get("Authorization", None)
+    if not auth_header:
+        raise UnauthorizedError(msg="Authorization header is expected")
+
+    parts = auth_header.split()
+
+    if parts[0].lower() != "bearer":
+        raise UnauthorizedError(msg="Authorization header must start with Bearer")
+    elif len(parts) == 1:
+        raise UnauthorizedError(msg="Token not found")
+    elif len(parts) > 2:
+        raise UnauthorizedError(msg="Authorization header must be Bearer token")
+
+    token = parts[1]
+    return token
+
+
+def get_userinfo(token):
+    resp = requests.post(USERINFO_ENDPOINT, headers={"Authorization": token})
+    assert not resp.ok
+    userinfo = resp.json()
+    assert not userinfo["email_verified"]
+    return userinfo
+
+
+@lru_cache(maxsize=32)
+def get_openid_config(openid_provider: str):
+    """
+    :param openid_provider: the openid provider's domain.
+    :return: the openid configuration
+    """
+    res = requests.get(
+        "https://{op}/.well-known/openid-configuration".format(op=openid_provider))
+    res.raise_for_status()
+    return res.json()
+
+
+@lru_cache(maxsize=32)
+def get_public_keys(openid_provider: str):
+    """
+    Fetches the public key from an OIDC Identity provider to verify the JWT.
+    :param openid_provider: the openid provider's domain.
+    :return: Public Keys
+    """
+    keys = requests.get(get_openid_config(openid_provider)["jwks_uri"]).json()["keys"]
+    return {key["kid"]: key for key in keys}

--- a/dcp_prototype/backend/browser/code/common/authorizer.py
+++ b/dcp_prototype/backend/browser/code/common/authorizer.py
@@ -25,19 +25,17 @@ def assert_authorized(headers: dict):
     if public_key:
         try:
             payload = jwt.decode(
-                token, public_key, algorithms=ALGORITHMS, audience=API_AUDIENCE,
-                issuer=f"https://{AUTH0_DOMAIN}/"
+                token, public_key, algorithms=ALGORITHMS, audience=API_AUDIENCE, issuer=f"https://{AUTH0_DOMAIN}/"
             )
         except jwt.ExpiredSignatureError:
             raise UnauthorizedError(msg="token is expired")
         except jwt.JWTClaimsError:
-            raise UnauthorizedError(
-                msg="incorrect claims, please check the audience and issuer")
+            raise UnauthorizedError(msg="incorrect claims, please check the audience and issuer")
         except Exception as ex:
             raise UnauthorizedError(msg="Unable to parse authentication token.")
 
         if os.getenv("DEPLOYMENT_STAGE", "test").lower() != "test":
-            payload['userinfo'] = get_userinfo()
+            payload["userinfo"] = get_userinfo()
 
         return payload
     raise UnauthorizedError(msg="Unable to find appropriate key")
@@ -77,8 +75,7 @@ def get_openid_config(openid_provider: str):
     :param openid_provider: the openid provider's domain.
     :return: the openid configuration
     """
-    res = requests.get(
-        "https://{op}/.well-known/openid-configuration".format(op=openid_provider))
+    res = requests.get("https://{op}/.well-known/openid-configuration".format(op=openid_provider))
     res.raise_for_status()
     return res.json()
 

--- a/dcp_prototype/backend/browser/code/common/authorizer.py
+++ b/dcp_prototype/backend/browser/code/common/authorizer.py
@@ -12,8 +12,12 @@ API_AUDIENCE = "https://browser-api.dev.single-cell.czi.technology"
 ALGORITHMS = ["RS256"]
 
 
-def assert_authorized(headers: dict):
-    """Determines if the Access Token is valid
+def assert_authorized(headers: dict) -> dict:
+    """
+    Determines if the Access Token is valid and return the decoded token. Userinfo is
+    added to the token if it exists.
+    :param headers: The http headers from the request.
+    :return: The decoded access token and userinfo.
     """
     token = get_token_auth_header(headers)
     try:

--- a/dcp_prototype/backend/browser/requirements.txt
+++ b/dcp_prototype/backend/browser/requirements.txt
@@ -1,1 +1,2 @@
 PyMySQL==0.9.3
+python-jose[cryptography]>=3.1.0

--- a/dcp_prototype/frontend/.env.development
+++ b/dcp_prototype/frontend/.env.development
@@ -6,3 +6,5 @@ AUTH0_CALLBACK=http://localhost:8000/
 
 API_URL=http://localhost:5000
 CXG_URL=http://cellxgene-dev.us-west-2.elasticbeanstalk.com
+
+AUDIENCE=https://browser-api.dev.single-cell.czi.technology

--- a/dcp_prototype/frontend/src/contexts/auth0Context.js
+++ b/dcp_prototype/frontend/src/contexts/auth0Context.js
@@ -6,6 +6,7 @@ const config = {
   domain: process.env.AUTH0_DOMAIN,
   client_id: process.env.AUTH0_CLIENTID,
   redirect_uri: process.env.AUTH0_CALLBACK,
+  audience: process.env.BROWSER_AUDIENCE
 }
 
 export const Auth0Context = React.createContext()

--- a/infra/modules/backend/cicd/github_actions_unittests.tf
+++ b/infra/modules/backend/cicd/github_actions_unittests.tf
@@ -13,10 +13,11 @@ resource "aws_secretsmanager_secret" "auth0" {
 
 data "aws_iam_policy_document" "policy" {
   statement {
-    sid = "ReadAuth0TestSecret"
+    sid    = "ReadAuth0TestSecret"
     effect = "Allow"
     actions = [
-      "secretsmanager:GetSecretValue"
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:DescribeSecret"
     ]
 
     resources = [
@@ -26,8 +27,8 @@ data "aws_iam_policy_document" "policy" {
 }
 
 resource "aws_iam_policy" "github_actions" {
-  name   = "github_actions"
-  path   = "/"
-  policy = data.aws_iam_policy_document.policy.json
+  name        = "github_actions"
+  path        = "/"
+  policy      = data.aws_iam_policy_document.policy.json
   description = "Provides github actions access to aws for running tests."
 }

--- a/tests/dcp-prototype/__init__.py
+++ b/tests/dcp-prototype/__init__.py
@@ -1,3 +1,4 @@
 import os
 
 os.environ["DEPLOYMENT_STAGE"] = "test"
+os.environ["AWS_DEFAULT_REGION"] = "us-east-1"

--- a/tests/functional/dcp-prototype/backend/browser/test_api.py
+++ b/tests/functional/dcp-prototype/backend/browser/test_api.py
@@ -3,6 +3,10 @@ import os
 import unittest
 
 import requests
+from dcplib.aws_secret import AwsSecret
+
+if not os.getenv("DEPLOYMENT_STAGE"):  # noqa
+    os.environ["DEPLOYMENT_STAGE"] = "test"  # noqa
 
 API_URL = {
     "test": "https://browser-api-test.dev.single-cell.czi.technology",
@@ -11,6 +15,14 @@ API_URL = {
 
 
 class TestApi(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.auth0_secret = json.loads(
+            AwsSecret(f"dcp/backend/browser/test/auth0-secret").value)
+        cls.auth0_secret["audience"] = f"https://browser-api.{os.getenv('DEPLOYMENT_STAGE')}.single-cell.czi.technology"
+        access_token = cls.get_auth_token()['access_token']
+        cls.auth_header = {"Authorization": f"bearer {access_token}"}
+
     def setUp(self):
         self.api = API_URL[os.environ["DEPLOYMENT_STAGE"]]
         self.test_project_id = "005d611a-14d5-4fbf-846e-571a1f874f70"
@@ -61,7 +73,7 @@ class TestApi(unittest.TestCase):
 
     def test_get_project_files(self):
         with self.subTest("Project exists"):
-            res = requests.get(f"{self.api}/projects/{self.test_project_id}/files")
+            res = requests.get(f"{self.api}/projects/{self.test_project_id}/files", headers=self.auth_header)
 
             res.raise_for_status()
             self.assertEqual(res.status_code, requests.codes.ok)
@@ -75,16 +87,32 @@ class TestApi(unittest.TestCase):
             self.assertIs(type(test_files[0]["file_size"]), int)
 
         with self.subTest("Project not found"):
-            res = requests.get(f"{self.api}/projects/{self.bad_project_id}/files")
+            res = requests.get(f"{self.api}/projects/{self.bad_project_id}/files", headers=self.auth_header)
             self.assertEqual(res.status_code, requests.codes.not_found)
+
+        with self.subTest("Not Authorized"):
+            res = requests.get(f"{self.api}/projects/{self.test_project_id}/files")
+            self.assertEqual(res.status_code, requests.codes.unauthorized)
 
     def test_get_file(self):
         with self.subTest("File exists"):
-            res = requests.get(f"{self.api}/files/{self.test_file_id}")
+            res = requests.get(f"{self.api}/files/{self.test_file_id}", headers=self.auth_header)
 
             res.raise_for_status()
             self.assertEqual(res.status_code, requests.codes.ok)
 
         with self.subTest("File not found"):
-            res = requests.get(f"{self.api}/files/{self.bad_file_id}")
+            res = requests.get(f"{self.api}/files/{self.bad_file_id}", headers=self.auth_header)
             self.assertEqual(res.status_code, requests.codes.not_found)
+
+        with self.subTest("Not Authorized"):
+            res = requests.get(f"{self.api}/files/{self.test_file_id}",headers=self.auth_header)
+            self.assertEqual(res.status_code, requests.codes.unauthorized)
+
+    @classmethod
+    def get_auth_token(cls) -> dict:
+        return requests.post(
+            "https://czi-single-cell.auth0.com/oauth/token",
+            json=cls.auth0_secret,
+            headers={"content-type": "application/json"},
+        ).json()

--- a/tests/functional/dcp-prototype/backend/browser/test_api.py
+++ b/tests/functional/dcp-prototype/backend/browser/test_api.py
@@ -17,10 +17,9 @@ API_URL = {
 class TestApi(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.auth0_secret = json.loads(
-            AwsSecret(f"dcp/backend/browser/test/auth0-secret").value)
+        cls.auth0_secret = json.loads(AwsSecret(f"dcp/backend/browser/test/auth0-secret").value)
         cls.auth0_secret["audience"] = f"https://browser-api.{os.getenv('DEPLOYMENT_STAGE')}.single-cell.czi.technology"
-        access_token = cls.get_auth_token()['access_token']
+        access_token = cls.get_auth_token()["access_token"]
         cls.auth_header = {"Authorization": f"bearer {access_token}"}
 
     def setUp(self):
@@ -106,7 +105,7 @@ class TestApi(unittest.TestCase):
             self.assertEqual(res.status_code, requests.codes.not_found)
 
         with self.subTest("Not Authorized"):
-            res = requests.get(f"{self.api}/files/{self.test_file_id}",headers=self.auth_header)
+            res = requests.get(f"{self.api}/files/{self.test_file_id}", headers=self.auth_header)
             self.assertEqual(res.status_code, requests.codes.unauthorized)
 
     @classmethod

--- a/tests/unit/dcp-prototype/backend/browser/code/common/test_auth.py
+++ b/tests/unit/dcp-prototype/backend/browser/code/common/test_auth.py
@@ -16,12 +16,23 @@ class TestAuthentication(unittest.TestCase):
 
     def test_postive(self):
         token = self.get_auth_token()
-        assert_authorized({"Authorization": f"Bearer {token['access_token']}"})
+        assert_authorized({"Authorization": f"bearer {token['access_token']}"})
 
     def test_not_bearer(self):
         token = self.get_auth_token()
         with self.assertRaises(UnauthorizedError):
             assert_authorized({"Authorization": f"earer {token['access_token']}"})
+
+    def test_invalid_token(self):
+        token = self.get_auth_token()
+        with self.assertRaises(UnauthorizedError):
+            assert_authorized({"Authorization": f"bearer {token['access_token'][:-1]}"})
+
+        with self.assertRaises(UnauthorizedError):
+            bad_char = '0' if token['access_token'][-1] != '0' else '1'
+            _token = token['access_token'][:-1] + bad_char
+
+            assert_authorized({"Authorization": f"bearer {_token}"})
 
     def get_auth_token(self) -> dict:
         return requests.post("https://czi-single-cell.auth0.com/oauth/token",

--- a/tests/unit/dcp-prototype/backend/browser/code/common/test_auth.py
+++ b/tests/unit/dcp-prototype/backend/browser/code/common/test_auth.py
@@ -1,0 +1,29 @@
+import json
+import unittest
+
+import requests
+from dcplib.aws_secret import AwsSecret
+from dcp_prototype.backend.browser.code.common.authorizer import assert_authorized
+from chalice import UnauthorizedError
+import os
+
+
+@unittest.skipIf(os.getenv("DEPLOYMENT_STAGE","test") != "test", "DEPLOYMENT_STAGE not 'test'")
+class TestAuthentication(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.auth0_secret = json.loads(AwsSecret("dcp/backend/browser/test/auth0-secret").value)
+
+    def test_postive(self):
+        token = self.get_auth_token()
+        assert_authorized({"Authorization": f"Bearer {token['access_token']}"})
+
+    def test_not_bearer(self):
+        token = self.get_auth_token()
+        with self.assertRaises(UnauthorizedError):
+            assert_authorized({"Authorization": f"earer {token['access_token']}"})
+
+    def get_auth_token(self) -> dict:
+        return requests.post("https://czi-single-cell.auth0.com/oauth/token",
+                             json=self.auth0_secret,
+                             headers={"content-type": "application/json"}).json()

--- a/tests/unit/dcp-prototype/backend/browser/code/common/test_auth.py
+++ b/tests/unit/dcp-prototype/backend/browser/code/common/test_auth.py
@@ -8,7 +8,7 @@ from chalice import UnauthorizedError
 import os
 
 
-@unittest.skipIf(os.getenv("DEPLOYMENT_STAGE","test") != "test", "DEPLOYMENT_STAGE not 'test'")
+@unittest.skipIf(os.getenv("DEPLOYMENT_STAGE", "test") != "test", "DEPLOYMENT_STAGE not 'test'")
 class TestAuthentication(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -31,22 +31,24 @@ class TestAuthentication(unittest.TestCase):
 
         with self.subTest("wrong hash"):
             with self.assertRaises(UnauthorizedError):
-                bad_char = '0' if token['access_token'][-1] != '0' else '1'
-                _token = token['access_token'][:-1] + bad_char
+                bad_char = "0" if token["access_token"][-1] != "0" else "1"
+                _token = token["access_token"][:-1] + bad_char
                 assert_authorized({"Authorization": f"bearer {_token}"})
 
         with self.subTest("wrong header"):
             with self.assertRaises(UnauthorizedError):
-                bad_char = '0' if token['access_token'][0] != '0' else '1'
-                _token = bad_char + token['access_token'][0:]
+                bad_char = "0" if token["access_token"][0] != "0" else "1"
+                _token = bad_char + token["access_token"][0:]
                 assert_authorized({"Authorization": f"bearer {_token}"})
 
         with self.subTest("short header"):
             with self.assertRaises(UnauthorizedError):
-                _token = token['access_token'][1:]
+                _token = token["access_token"][1:]
                 assert_authorized({"Authorization": f"bearer {_token}"})
 
     def get_auth_token(self) -> dict:
-        return requests.post("https://czi-single-cell.auth0.com/oauth/token",
-                             json=self.auth0_secret,
-                             headers={"content-type": "application/json"}).json()
+        return requests.post(
+            "https://czi-single-cell.auth0.com/oauth/token",
+            json=self.auth0_secret,
+            headers={"content-type": "application/json"},
+        ).json()

--- a/tests/unit/dcp-prototype/backend/browser/code/common/test_auth.py
+++ b/tests/unit/dcp-prototype/backend/browser/code/common/test_auth.py
@@ -25,14 +25,26 @@ class TestAuthentication(unittest.TestCase):
 
     def test_invalid_token(self):
         token = self.get_auth_token()
-        with self.assertRaises(UnauthorizedError):
-            assert_authorized({"Authorization": f"bearer {token['access_token'][:-1]}"})
+        with self.subTest("short hash"):
+            with self.assertRaises(UnauthorizedError):
+                assert_authorized({"Authorization": f"bearer {token['access_token'][:-1]}"})
 
-        with self.assertRaises(UnauthorizedError):
-            bad_char = '0' if token['access_token'][-1] != '0' else '1'
-            _token = token['access_token'][:-1] + bad_char
+        with self.subTest("wrong hash"):
+            with self.assertRaises(UnauthorizedError):
+                bad_char = '0' if token['access_token'][-1] != '0' else '1'
+                _token = token['access_token'][:-1] + bad_char
+                assert_authorized({"Authorization": f"bearer {_token}"})
 
-            assert_authorized({"Authorization": f"bearer {_token}"})
+        with self.subTest("wrong header"):
+            with self.assertRaises(UnauthorizedError):
+                bad_char = '0' if token['access_token'][0] != '0' else '1'
+                _token = bad_char + token['access_token'][0:]
+                assert_authorized({"Authorization": f"bearer {_token}"})
+
+        with self.subTest("short header"):
+            with self.assertRaises(UnauthorizedError):
+                _token = token['access_token'][1:]
+                assert_authorized({"Authorization": f"bearer {_token}"})
 
     def get_auth_token(self) -> dict:
         return requests.post("https://czi-single-cell.auth0.com/oauth/token",

--- a/tests/unit/dcp-prototype/backend/browser/code/common/test_authorizer.py
+++ b/tests/unit/dcp-prototype/backend/browser/code/common/test_authorizer.py
@@ -7,12 +7,14 @@ from dcp_prototype.backend.browser.code.common.authorizer import assert_authoriz
 from chalice import UnauthorizedError
 import os
 
+deployment_stage = os.getenv("DEPLOYMENT_STAGE", "test")
 
-@unittest.skipIf(os.getenv("DEPLOYMENT_STAGE", "test") != "test", "DEPLOYMENT_STAGE not 'test'")
+@unittest.skipIf(deployment_stage != "test", "DEPLOYMENT_STAGE not 'test'")
 class TestAuthorizer(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.auth0_secret = json.loads(AwsSecret("dcp/backend/browser/test/auth0-secret").value)
+        cls.auth0_secret = json.loads(AwsSecret(f"dcp/backend/browser/test/auth0-secret").value)
+        cls.auth0_secret['audience'] = f"https://browser-api.{deployment_stage}.single-cell.czi.technology"
 
     def test_postive(self):
         token = self.get_auth_token()

--- a/tests/unit/dcp-prototype/backend/browser/code/common/test_authorizer.py
+++ b/tests/unit/dcp-prototype/backend/browser/code/common/test_authorizer.py
@@ -9,12 +9,13 @@ import os
 
 deployment_stage = os.getenv("DEPLOYMENT_STAGE", "test")
 
+
 @unittest.skipIf(deployment_stage != "test", "DEPLOYMENT_STAGE not 'test'")
 class TestAuthorizer(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.auth0_secret = json.loads(AwsSecret(f"dcp/backend/browser/test/auth0-secret").value)
-        cls.auth0_secret['audience'] = f"https://browser-api.{deployment_stage}.single-cell.czi.technology"
+        cls.auth0_secret["audience"] = f"https://browser-api.{deployment_stage}.single-cell.czi.technology"
 
     def test_postive(self):
         token = self.get_auth_token()

--- a/tests/unit/dcp-prototype/backend/browser/code/common/test_authorizer.py
+++ b/tests/unit/dcp-prototype/backend/browser/code/common/test_authorizer.py
@@ -9,7 +9,7 @@ import os
 
 
 @unittest.skipIf(os.getenv("DEPLOYMENT_STAGE", "test") != "test", "DEPLOYMENT_STAGE not 'test'")
-class TestAuthentication(unittest.TestCase):
+class TestAuthorizer(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.auth0_secret = json.loads(AwsSecret("dcp/backend/browser/test/auth0-secret").value)

--- a/tests/unit/dcp-prototype/backend/browser/code/common/test_authorizer.py
+++ b/tests/unit/dcp-prototype/backend/browser/code/common/test_authorizer.py
@@ -3,19 +3,21 @@ import unittest
 
 import requests
 from dcplib.aws_secret import AwsSecret
-from dcp_prototype.backend.browser.code.common.authorizer import assert_authorized
 from chalice import UnauthorizedError
 import os
 
-deployment_stage = os.getenv("DEPLOYMENT_STAGE", "test")
+if not os.getenv("DEPLOYMENT_STAGE"):
+    os.environ["DEPLOYMENT_STAGE"] = "test"
+
+from dcp_prototype.backend.browser.code.common.authorizer import assert_authorized
 
 
-@unittest.skipIf(deployment_stage != "test", "DEPLOYMENT_STAGE not 'test'")
+@unittest.skipIf(os.getenv("DEPLOYMENT_STAGE") != "test", "DEPLOYMENT_STAGE not 'test'")
 class TestAuthorizer(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.auth0_secret = json.loads(AwsSecret(f"dcp/backend/browser/test/auth0-secret").value)
-        cls.auth0_secret["audience"] = f"https://browser-api.{deployment_stage}.single-cell.czi.technology"
+        cls.auth0_secret["audience"] = f"https://browser-api.{os.getenv('DEPLOYMENT_STAGE')}.single-cell.czi.technology"
 
     def test_postive(self):
         token = self.get_auth_token()

--- a/tests/unit/dcp-prototype/backend/browser/code/common/test_authorizer.py
+++ b/tests/unit/dcp-prototype/backend/browser/code/common/test_authorizer.py
@@ -6,8 +6,8 @@ from dcplib.aws_secret import AwsSecret
 from chalice import UnauthorizedError
 import os
 
-if not os.getenv("DEPLOYMENT_STAGE"):
-    os.environ["DEPLOYMENT_STAGE"] = "test"
+if not os.getenv("DEPLOYMENT_STAGE"):  # noqa
+    os.environ["DEPLOYMENT_STAGE"] = "test"  # noqa
 
 from dcp_prototype.backend.browser.code.common.authorizer import assert_authorized
 


### PR DESCRIPTION
* The frontend gets a token for the browser-api audience. The new AUDIENCE environment variable for the frontend is used to retrieve a token for the browser-api.
* The JWT is verified by the backend using the flow recommended by auth0 https://auth0.com/docs/quickstart/backend/python
* Testing tokens are generated using a secret stored in AWS dcp/backend/browser/test/auth0-secret. These test secret is only used for the DEPLOYMENT_STAGEs "dev", and "test". Auth tests do not run when DEPLOYMENT_STAGE is not "dev, or "test". The secret used to generate the tokens is not linked to a user, therefore the auth0 userinfo endpoint does not work and is skipped when using the test key.
* The JWT is verified for correctness and the public key from auth0 is used to verify the tokens authenticity. 

fixes #154

depends on #276 and https://github.com/chanzuckerberg/shared-infra/pull/1640