### PR TITLE
Github Action to Automated Browser Backend Deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy Backend
 on:
   push:
     branch:
-      - master
+      - tsmith/cd
     path:
       - 'browser/backend'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+name: Deploy Backend
+
+on:
+  push:
+    branch:
+      - master
+    path:
+      - 'browser/backend'
+
+env:
+  DEPLOYMENT_STAGE: 'dev'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-1
+    - name: Lint code
+      run: |
+        pip install -r browser/backend/requirements-dev.txt
+        $(MAKE) clean -C browser/backend

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,6 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r browser/backend/requirements-dev.txt
-        apt-get install moreutils
+        sudo apt-get install moreutils
     - name: deploy backend
       run: make package -C browser/backend

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,4 +28,4 @@ jobs:
         pip install -r browser/backend/requirements-dev.txt
         sudo apt-get install moreutils
     - name: deploy backend
-      run: make deploy -C browser/backend
+      run: make ci-deploy -C browser/backend

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,4 +28,4 @@ jobs:
     - name: Install dependencies
       run: pip install -r browser/backend/requirements-dev.txt
     - name: deploy backend
-      run: $(MAKE) clean -C browser/backend
+      run: make clean -C browser/backend

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy Backend
 on:
   push:
     branch:
-      - tsmith/cd
+      - tsmith/cd-1
     path:
       - 'browser/backend'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,4 +28,4 @@ jobs:
         pip install -r browser/backend/requirements-dev.txt
         sudo apt-get install moreutils
     - name: deploy backend
-      run: make package -C browser/backend
+      run: make deploy -C browser/backend

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,4 +28,4 @@ jobs:
         pip install -r browser/backend/requirements-dev.txt
         sudo apt-get install moreutils
     - name: deploy backend
-      run: make ci-deploy -C browser/backend
+      run: make ci-deploy -C browser/backend/chalice

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,8 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-east-1
     - name: Install dependencies
-      run: pip install -r browser/backend/requirements-dev.txt
+      run: |
+        pip install -r browser/backend/requirements-dev.txt
+        apt-get install moreutils
     - name: deploy backend
       run: make package -C browser/backend

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,17 +1,15 @@
-name: Deploy Backend
+name: Deploy
 
 on:
   push:
     branch:
       - tsmith/cd-1
-    path:
-      - 'browser/backend'
 
 env:
   DEPLOYMENT_STAGE: 'dev'
 
 jobs:
-  deploy:
+  backend:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,8 +25,7 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-east-1
-    - name: install requirements
-      run: |
-        pip install -r browser/backend/requirements-dev.txt
+    - name: Install dependencies
+      run: pip install -r browser/backend/requirements-dev.txt
     - name: deploy backend
-        $(MAKE) clean -C browser/backend
+      run: $(MAKE) clean -C browser/backend

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,4 +28,4 @@ jobs:
     - name: Install dependencies
       run: pip install -r browser/backend/requirements-dev.txt
     - name: deploy backend
-      run: make clean -C browser/backend
+      run: make package -C browser/backend

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,8 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-east-1
-    - name: Lint code
+    - name: install requirements
       run: |
         pip install -r browser/backend/requirements-dev.txt
+    - name: deploy backend
         $(MAKE) clean -C browser/backend

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy
 on:
   push:
     branch:
-      - tsmith/cd-1
+      - master
 
 env:
   DEPLOYMENT_STAGE: 'dev'

--- a/browser/backend/chalice/Makefile
+++ b/browser/backend/chalice/Makefile
@@ -62,7 +62,7 @@ local-server: package
 retrieve-deployed:
 	if ![[ -d "$(DEPLOYED_PATH)" ]]; then mkdir $(DEPLOYED_PATH); fi
 	aws s3 cp $(S3_DEPLOYMENT_FILE) $(DEPLOYED)
-
+	cat $(DEPLOYED)
 .PHONY: upload-deployed
 upload-deployed:
 	aws s3 cp $(DEPLOYED) $(S3_DEPLOYMENT_FILE)

--- a/browser/backend/chalice/Makefile
+++ b/browser/backend/chalice/Makefile
@@ -60,7 +60,7 @@ local-server: package
 
 .PHONY: retrieve-deployed
 retrieve-deployed:
-	if ![[ -d "$(DEPLOYED_PATH)" ]]; then mkdir $(DEPLOYED_PATH); fi
+	if [[ ! -d "$(DEPLOYED_PATH)" ]]; then mkdir $(DEPLOYED_PATH); fi
 	aws s3 cp $(S3_DEPLOYMENT_FILE) $(DEPLOYED)
 	
 .PHONY: upload-deployed

--- a/browser/backend/chalice/Makefile
+++ b/browser/backend/chalice/Makefile
@@ -6,8 +6,8 @@ export APP_NAME=browser-api
 export EXPORT_ENV_VARS_TO_LAMBDA=APP_NAME DEPLOYMENT_STAGE
 export PYTHONHASHSEED=0
 export S3_DEPLOYMENT_FILE=s3://org-dcp-infra-$(ACCOUNT_ID)/chalice/envs/$(DEPLOYMENT_STAGE)/deployed.json
-export DEPLOYED_PATH= .chalice/deployed
-export DEPLOYED = $(DEPLOYED_PATH)/$(DEPLOYMENT_STAGE).json
+export LOCAL_DEPLOYED_PATH=.chalice/deployed
+export LOCAL_DEPLOYED_FILE=$(LOCAL_DEPLOYED_PATH)/$(DEPLOYMENT_STAGE).json
 ifndef DEPLOYMENT_STAGE
 $(error Please set DEPLOYMENT_STAGE in environment before running make commands)
 endif
@@ -60,12 +60,12 @@ local-server: package
 
 .PHONY: retrieve-deployed
 retrieve-deployed:
-	if [[ ! -d "$(DEPLOYED_PATH)" ]]; then mkdir $(DEPLOYED_PATH); fi
-	aws s3 cp $(S3_DEPLOYMENT_FILE) $(DEPLOYED)
+	if [[ ! -d "$(LOCAL_DEPLOYED_PATH)" ]]; then mkdir $(LOCAL_DEPLOYED_PATH); fi
+	aws s3 cp $(S3_DEPLOYMENT_FILE) $(LOCAL_DEPLOYED_FILE)
 	
 .PHONY: upload-deployed
 upload-deployed:
-	aws s3 cp $(DEPLOYED) $(S3_DEPLOYMENT_FILE)
+	aws s3 cp $(LOCAL_DEPLOYED_FILE) $(S3_DEPLOYMENT_FILE)
 
 .PHONY: remove-deployed
 remove-deployed:

--- a/browser/backend/chalice/Makefile
+++ b/browser/backend/chalice/Makefile
@@ -5,7 +5,7 @@ export ACCOUNT_ID=$(shell aws sts get-caller-identity --query Account --output t
 export APP_NAME=browser-api
 export EXPORT_ENV_VARS_TO_LAMBDA=APP_NAME DEPLOYMENT_STAGE
 export PYTHONHASHSEED=0
-export S3_DEPLOYMENT_FILE=s3://org-dcp-infra-$(ACCOUNT_ID)/terraform/envs/$(DEPLOYMENT_STAGE)/deployed.json
+export S3_DEPLOYMENT_FILE=s3://org-dcp-infra-$(ACCOUNT_ID)/chalice/envs/$(DEPLOYMENT_STAGE)/deployed.json
 export DEPLOYED_PATH= .chalice/deployed
 export DEPLOYED = $(DEPLOYED_PATH)/$(DEPLOYMENT_STAGE).json
 ifndef DEPLOYMENT_STAGE

--- a/browser/backend/chalice/Makefile
+++ b/browser/backend/chalice/Makefile
@@ -27,8 +27,8 @@ deploy: package
 	chalice deploy --stage $(DEPLOYMENT_STAGE) --api-gateway-stage $(DEPLOYMENT_STAGE)
 	make upload-deployed
 
-.PHONY: ci
-ci: retrieve-deployed
+.PHONY: ci-deploy
+ci-deploy: retrieve-deployed
 	make deploy
 
 .PHONY: package

--- a/browser/backend/chalice/Makefile
+++ b/browser/backend/chalice/Makefile
@@ -62,7 +62,7 @@ local-server: package
 retrieve-deployed:
 	if ![[ -d "$(DEPLOYED_PATH)" ]]; then mkdir $(DEPLOYED_PATH); fi
 	aws s3 cp $(S3_DEPLOYMENT_FILE) $(DEPLOYED)
-	cat $(DEPLOYED)
+	
 .PHONY: upload-deployed
 upload-deployed:
 	aws s3 cp $(DEPLOYED) $(S3_DEPLOYMENT_FILE)

--- a/browser/backend/chalice/Makefile
+++ b/browser/backend/chalice/Makefile
@@ -5,7 +5,9 @@ export ACCOUNT_ID=$(shell aws sts get-caller-identity --query Account --output t
 export APP_NAME=browser-api
 export EXPORT_ENV_VARS_TO_LAMBDA=APP_NAME DEPLOYMENT_STAGE
 export PYTHONHASHSEED=0
-
+export S3_DEPLOYMENT_FILE=s3://org-dcp-infra-$(ACCOUNT_ID)/terraform/envs/$(DEPLOYMENT_STAGE)/deployed.json
+export DEPLOYED_PATH= .chalice/deployed
+export DEPLOYED = $(DEPLOYED_PATH)/$(DEPLOYMENT_STAGE).json
 ifndef DEPLOYMENT_STAGE
 $(error Please set DEPLOYMENT_STAGE in environment before running make commands)
 endif
@@ -17,10 +19,17 @@ clean:
 .PHONY: destroy
 destroy:
 	chalice delete --stage $(DEPLOYMENT_STAGE)
+	make remove-deployed
+
 
 .PHONY: deploy
 deploy: package
 	chalice deploy --stage $(DEPLOYMENT_STAGE) --api-gateway-stage $(DEPLOYMENT_STAGE)
+	make upload-deployed
+
+.PHONY: ci
+ci: retrieve-deployed
+	make deploy
 
 .PHONY: package
 package: build-chalice-config
@@ -48,3 +57,16 @@ build-chalice-config:
 .PHONY: local-server
 local-server: package
 	python local_server.py
+
+.PHONY: retrieve-deployed
+retrieve-deployed:
+	if ![[ -d "$(DEPLOYED_PATH)" ]]; then mkdir $(DEPLOYED_PATH); fi
+	aws s3 cp $(S3_DEPLOYMENT_FILE) $(DEPLOYED)
+
+.PHONY: upload-deployed
+upload-deployed:
+	aws s3 cp $(DEPLOYED) $(S3_DEPLOYMENT_FILE)
+
+.PHONY: remove-deployed
+remove-deployed:
+	aws s3 rm $(S3_DEPLOYMENT_FILE)

--- a/browser/backend/requirements-dev.txt
+++ b/browser/backend/requirements-dev.txt
@@ -1,3 +1,3 @@
 furl
 -r requirements.txt
--r ../../../requirements-dev.txt
+-r ../../requirements-dev.txt

--- a/infra/envs/dev/main.tf
+++ b/infra/envs/dev/main.tf
@@ -92,9 +92,14 @@ module "browser_backend" {
 module "cicd" {
   source = "../../modules/backend/cicd"
 
+  account_id          = data.aws_caller_identity.current.account_id
+  api_gateway_staging = var.api_gateway_staging
+  api_gateway_dev     = var.api_gateway_dev
+
   # Variables used for tagging
   env     = var.deployment_stage
   project = "single-cell"
   service = "cicd"
   owner   = "czi-single-cell"
+
 }

--- a/infra/envs/dev/terraform.tfvars.example
+++ b/infra/envs/dev/terraform.tfvars.example
@@ -10,3 +10,7 @@ browser_preferred_maintenance_window = "sat:09:08-sat:09:38"
 refer_secret="a 64 character long random string"
 route53_zone_id= "zoneid"
 api_gateway_id ="addsavtrrav"
+
+// CICD
+api_gateway_staging=""
+api_gateway_dev=""

--- a/infra/envs/dev/terraform.tfvars.example
+++ b/infra/envs/dev/terraform.tfvars.example
@@ -12,5 +12,5 @@ route53_zone_id= "zoneid"
 api_gateway_id ="addsavtrrav"
 
 // CICD
-api_gateway_staging=""
-api_gateway_dev=""
+api_gateway_staging="The id of the the api-gateway created when first deploying the browser backend for staging"
+api_gateway_dev="The id of the the api-gateway created when first deploying the browser backend for dev"

--- a/infra/envs/dev/variables.tf
+++ b/infra/envs/dev/variables.tf
@@ -42,3 +42,12 @@ variable "route53_zone_id" {
 variable "api_gateway_id" {
   type = string
 }
+
+// CICD
+variable "api_gateway_staging" {
+  type = string
+}
+
+variable "api_gateway_dev" {
+  type = string
+}

--- a/infra/modules/backend/cicd/github_actions_unittests.tf
+++ b/infra/modules/backend/cicd/github_actions_unittests.tf
@@ -24,6 +24,90 @@ data "aws_iam_policy_document" "policy" {
       aws_secretsmanager_secret.auth0.arn,
     ]
   }
+  statement {
+    sid     = "ChaliceDeployeAPIGateway"
+    effect  = "Allow"
+    actions = ["apigateway:*"]
+    resources = [
+      "arn:aws:apigateway:us-east-1::/restapis/${var.api_gateway_dev}",
+      "arn:aws:apigateway:us-east-1::/restapis/${var.api_gateway_staging}",
+      "arn:aws:apigateway:us-east-1::/restapis/${var.api_gateway_dev}/*",
+      "arn:aws:apigateway:us-east-1::/restapis/${var.api_gateway_staging}/*"
+    ]
+  }
+  statement {
+    sid       = "ChaliceAPIGateway"
+    effect    = "Allow"
+    actions   = ["apigateway:POST"]
+    resources = ["arn:aws:apigateway:us-east-1::/restapis"]
+
+  }
+  statement {
+    sid    = "ChaliceLambdas"
+    effect = "Allow"
+    actions = [
+      "lambda:CreateFunction",
+      "lambda:TagResource",
+      "lambda:DeleteProvisionedConcurrencyConfig",
+      "lambda:GetFunctionConfiguration",
+      "lambda:UntagResource",
+      "lambda:PutFunctionConcurrency",
+      "lambda:GetProvisionedConcurrencyConfig",
+      "lambda:ListTags",
+      "lambda:PutFunctionEventInvokeConfig",
+      "lambda:DeleteFunctionEventInvokeConfig",
+      "lambda:DeleteFunction",
+      "lambda:UpdateFunctionEventInvokeConfig",
+      "lambda:GetFunction",
+      "lambda:UpdateFunctionConfiguration",
+      "lambda:AddPermission",
+      "lambda:GetFunctionConcurrency",
+      "lambda:GetFunctionEventInvokeConfig",
+      "lambda:PutProvisionedConcurrencyConfig",
+      "lambda:UpdateFunctionCode",
+      "lambda:DeleteFunctionConcurrency",
+      "lambda:PublishVersion",
+      "lambda:RemovePermission",
+      "lambda:GetPolicy"
+    ]
+    resources = [
+      "arn:aws:lambda:us-east-1:${var.account_id}:function:browser-api-dev",
+      "arn:aws:lambda:us-east-1:${var.account_id}:function:browser-api-staging"
+    ]
+  }
+  statement {
+    sid    = "ChaliceIAM"
+    effect = "Allow"
+    actions = [
+      "iam:UntagRole",
+      "iam:TagRole",
+      "iam:CreateRole",
+      "iam:AttachRolePolicy",
+      "iam:PutRolePolicy",
+      "iam:PassRole",
+      "iam:DeleteRolePolicy",
+      "iam:GetRole",
+      "iam:UpdateRoleDescription",
+      "iam:DeleteRole",
+      "iam:UpdateRole",
+      "iam:GetRolePolicy",
+    ]
+    resources = [
+      "arn:aws:iam::${var.account_id}:role/browser-api-dev-api_handler",
+      "arn:aws:iam::${var.account_id}:role/browser-api-staging-api_handler",
+    ]
+  }
+  statement {
+    sid    = "ChaliceS3"
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject"
+    ]
+    resources = [
+      "arn:aws:s3:::org-dcp-infra-${var.account_id}/chalice/*"
+    ]
+  }
 }
 
 resource "aws_iam_policy" "github_actions" {

--- a/infra/modules/backend/cicd/github_actions_unittests.tf
+++ b/infra/modules/backend/cicd/github_actions_unittests.tf
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "policy" {
     ]
   }
   statement {
-    sid     = "ChaliceDeployeAPIGateway"
+    sid     = "ChaliceDeployedAPIGateway"
     effect  = "Allow"
     actions = ["apigateway:*"]
     resources = [

--- a/infra/modules/backend/cicd/variables.tf
+++ b/infra/modules/backend/cicd/variables.tf
@@ -10,3 +10,15 @@ variable "service" {
 variable "owner" {
   type = string
 }
+
+variable "account_id" {
+  type = string
+}
+
+variable "api_gateway_staging" {
+  type = string
+}
+
+variable "api_gateway_dev" {
+  type = string
+}


### PR DESCRIPTION
- Adding github actions to automate the deployment of the browser backend when the `master` branch changes.
- A new file is uploaded to the infra s3 bucket. This files contains the current configuration for the chalice deployment. This make it easier to reuse the existing deployed chalice app rather than creating a new chalice app in AWS. A deployment file is stored for each deployment stage. 
- The IAM policy for github_actions has been update to allow github to deploy chalice apps. If a new deployment stage is created, the policy will need to be updated.
- Chalice apps for new stage must still be deployed from a local machine first before github can automate the deployment.
- Only the `dev` environment is automatically deployed.