### PR TITLE
Continuous Deploy Frontend

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy
 on:
   push:
     branch:
-      - tsmith/cd-frontend
+      - master
 
 env:
   DEPLOYMENT_STAGE: 'dev'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,3 +29,20 @@ jobs:
         sudo apt-get install moreutils
     - name: deploy backend
       run: make ci-deploy -C browser/backend/chalice
+
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-1
+    - name: Setup Node.js
+      uses: actions/setup-node@v1
+    - name: Install Gatsby
+      run: npm install -g gatsby
+    - name: Deploy Frontend
+      run: make deploy -C /browser/backend

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy
 on:
   push:
     branch:
-      - master
+      - tsmith/cd-frontend
 
 env:
   DEPLOYMENT_STAGE: 'dev'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,4 +45,4 @@ jobs:
     - name: Install Gatsby
       run: npm install -g gatsby
     - name: Deploy Frontend
-      run: make deploy -C /browser/backend
+      run: make deploy -C frontend/backend

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,4 +45,4 @@ jobs:
     - name: Install Gatsby
       run: npm install -g gatsby
     - name: Deploy Frontend
-      run: make deploy -C frontend/backend
+      run: make deploy -C browser/frontend

--- a/infra/envs/dev/main.tf
+++ b/infra/envs/dev/main.tf
@@ -95,6 +95,7 @@ module "cicd" {
   account_id          = data.aws_caller_identity.current.account_id
   api_gateway_staging = var.api_gateway_staging
   api_gateway_dev     = var.api_gateway_dev
+  deployment_stage    = var.deployment_stage
 
   # Variables used for tagging
   env     = var.deployment_stage

--- a/infra/modules/backend/cicd/github_actions_unittests.tf
+++ b/infra/modules/backend/cicd/github_actions_unittests.tf
@@ -113,7 +113,8 @@ data "aws_iam_policy_document" "policy" {
     effect = "Allow"
     actions = [
       "s3:PutObject",
-      "s3:GetObject"
+      "s3:GetObject",
+      "s3:ListObjectsV2"
     ]
     resources = [
       "arn:aws:s3:::dcp-static-site-${var.deployment_stage}-${var.account_id}/*"

--- a/infra/modules/backend/cicd/github_actions_unittests.tf
+++ b/infra/modules/backend/cicd/github_actions_unittests.tf
@@ -114,10 +114,11 @@ data "aws_iam_policy_document" "policy" {
     actions = [
       "s3:PutObject",
       "s3:GetObject",
-      "s3:ListObjectsV2"
+      "s3:ListBucket"
     ]
     resources = [
-      "arn:aws:s3:::dcp-static-site-${var.deployment_stage}-${var.account_id}/*"
+      "arn:aws:s3:::dcp-static-site-${var.deployment_stage}-${var.account_id}/*",
+      "arn:aws:s3:::dcp-static-site-${var.deployment_stage}-${var.account_id}"
     ]
   }
 }

--- a/infra/modules/backend/cicd/github_actions_unittests.tf
+++ b/infra/modules/backend/cicd/github_actions_unittests.tf
@@ -108,6 +108,17 @@ data "aws_iam_policy_document" "policy" {
       "arn:aws:s3:::org-dcp-infra-${var.account_id}/chalice/*"
     ]
   }
+  statement {
+    sid    = "GatsbyS3"
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject"
+    ]
+    resources = [
+      "arn:aws:s3:::dcp-static-site-${var.deployment_stage}-${var.account_id}/*"
+    ]
+  }
 }
 
 resource "aws_iam_policy" "github_actions" {

--- a/infra/modules/backend/cicd/variables.tf
+++ b/infra/modules/backend/cicd/variables.tf
@@ -1,3 +1,6 @@
+variable deployment_stage {
+  type = string
+}
 variable "env" {
   type = string
 }


### PR DESCRIPTION
Deploy the frontend to dev whenever master is updated. This will still require us to invalid the cloudfront cache before the changes are seen. This will be automated in the future.